### PR TITLE
Travis CI, codecov, and coveralls tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+## Documentation: http://docs.travis-ci.com/user/languages/julia/
+language: julia
+os:
+  - linux
+  - osx
+julia:
+  - 0.7
+  - 1.0
+  - nightly
+notifications:
+  email: false
+git:
+  depth: 99999999
+
+## uncomment the following lines to allow failures on nightly julia
+## (tests will run but not make your overall status red)
+#matrix:
+#  allow_failures:
+#  - julia: nightly
+
+## uncomment and modify the following lines to manually install system packages
+#addons:
+#  apt: # apt-get for linux
+#    packages:
+#    - gfortran
+#before_script: # homebrew for mac
+#  - if [ $TRAVIS_OS_NAME = osx ]; then brew install gcc; fi
+
+## uncomment the following lines to override the default test script
+#script:
+#  - julia -e 'Pkg.clone(pwd()); Pkg.build("GCMFaces"); Pkg.test("GCMFaces"; coverage=true)'
+after_success:
+  # push coverage results to Coveralls
+  - julia -e 'cd(Pkg.dir("GCMFaces")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+  # push coverage results to Codecov
+  - julia -e 'cd(Pkg.dir("GCMFaces")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/Project.toml
+++ b/Project.toml
@@ -5,3 +5,9 @@ version = "0.1.0"
 
 [deps]
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # GCMFaces.jl
 
+
+[![Travis Build Status](https://api.travis-ci.org/gaelforget/GCMFaces_jl.svg?branch=ci_tests_etc)](https://travis-ci.org/gaelforget/GCMFaces_jl)
+[![codecov](https://codecov.io/gh/gaelforget/GCMFaces_jl/branch/ci_tests_etc/graph/badge.svg)](https://codecov.io/gh/gaelforget/GCMFaces_jl)
+[![Coverage Status](https://coveralls.io/repos/github/gaelforget/GCMFaces_jl/badge.svg?branch=ci_tests_etc)](https://coveralls.io/github/gaelforget/GCMFaces_jl?branch=ci_tests_etc)
+
 This repository contains the `GCMFaces.jl` package introduced at the [JuliaCon-2018](http://juliacon.org/2018/) conference by [this presentation](https://youtu.be/RDxAy_zSUvg). The provided code has been tested with `julia v0.7 to  v1.0` but is still regarded as a **preliminary implementation**.
 
 ### Installation And Usage

--- a/src/gcmfaces_calc.jl
+++ b/src/gcmfaces_calc.jl
@@ -74,7 +74,7 @@ tmp00=max(tmp00,maximum(tmp0));
 nbt=ceil(1.1*2*tmp00^2);
 dt=1.;
 T=nbt*dt;
-println("nbt in smooth="*"$nbt")
+#println("nbt in smooth="*"$nbt")
 
 #diffusion operator:
 Kux=DXCsm*DXCsm/T/2;

--- a/src/gcmfaces_grids.jl
+++ b/src/gcmfaces_grids.jl
@@ -7,7 +7,7 @@ GCMGridSpec() = GCMGridSpec("LLC90")
 
 function GCMGridSpec(gridName)
 
-    global grDir, nFaces, grTopo, ioSize, facesSize, ioPrec;
+global grDir, nFaces, grTopo, ioSize, facesSize, ioPrec;
 
 if gridName=="LLC90";
     grDir="GRID_LLC90/";
@@ -31,10 +31,10 @@ elseif gridName=="LL360";
     facesSize=[360 160];
     ioPrec=Float32;
 else;
-  error("unknown gridName case");
+    error("unknown gridName case");
 end;
 
-println("Grid has been defined.")
+return "GCMGridSpec: passed"
 
 end
 
@@ -42,37 +42,39 @@ end
 
 function GCMGridLoad()
 
-    global XC, XG, YC, YG, RAC, RAZ, DXC, DXG, DYC, DYG, hFacC, hFacS, hFacW, Depth;
+global XC, XG, YC, YG, RAC, RAZ, DXC, DXG, DYC, DYG, hFacC, hFacS, hFacW, Depth;
 
-    list0=("XC","XG","YC","YG","RAC","RAZ","DXC","DXG","DYC","DYG","hFacC","hFacS","hFacW","Depth");
-    for ii=1:length(list0);
-        tmp1=read_bin(grDir*list0[ii]*".data",ioPrec);
-        tmp2=Symbol(list0[ii]);
-        @eval (($tmp2) = ($tmp1))
-    end
+list0=("XC","XG","YC","YG","RAC","RAZ","DXC","DXG","DYC","DYG","hFacC","hFacS","hFacW","Depth");
+for ii=1:length(list0);
+    tmp1=read_bin(grDir*list0[ii]*".data",ioPrec);
+    tmp2=Symbol(list0[ii]);
+    @eval (($tmp2) = ($tmp1))
+end
 
-    println("Grid has been loaded.")
+return "GCMGridLoad: passed"
 
 end
 
 function GCMGridOnes(grTp,nF,nP)
 
-    global grDir, nFaces, grTopo, ioSize, facesSize, ioPrec;
-    global XC, XG, YC, YG, RAC, RAZ, DXC, DXG, DYC, DYG, hFacC, hFacS, hFacW, Depth;
+global grDir, nFaces, grTopo, ioSize, facesSize, ioPrec;
+global XC, XG, YC, YG, RAC, RAZ, DXC, DXG, DYC, DYG, hFacC, hFacS, hFacW, Depth;
 
-    grDir=""
-    grTopo=grTp
-    nFaces=nF
-    ioSize=[nP nP*nF];
-    facesSize=fill(nP,(nF,2));
-    ioPrec=Float32;
+grDir=""
+grTopo=grTp
+nFaces=nF
+ioSize=[nP nP*nF];
+facesSize=fill(nP,(nF,2));
+ioPrec=Float32;
 
-    list0=("XC","XG","YC","YG","RAC","RAZ","DXC","DXG","DYC","DYG","hFacC","hFacS","hFacW","Depth");
-    for ii=1:length(list0);
-        tmp1=fill(1.,nP,nP*nF);
-        tmp1=convert2gcmfaces(tmp1);
-        tmp2=Symbol(list0[ii]);
-        @eval (($tmp2) = ($tmp1))
-    end
+list0=("XC","XG","YC","YG","RAC","RAZ","DXC","DXG","DYC","DYG","hFacC","hFacS","hFacW","Depth");
+for ii=1:length(list0);
+    tmp1=fill(1.,nP,nP*nF);
+    tmp1=convert2gcmfaces(tmp1);
+    tmp2=Symbol(list0[ii]);
+    @eval (($tmp2) = ($tmp1))
+end
+
+return "GCMGridOnes: passed"
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,17 @@
+using Test
 using GCMFaces
-@static if VERSION < v"0.7.0-DEV.2005"
-    using Base.Test
-else
-    using Test
-end
 
-# write your own tests here
-@test 1 == 2
+@testset "GCMFaces tests:" begin
+    N=200
+    Npt=6*N*N
+    @test GCMGridOnes("cs",6,N) == "GCMGridOnes: passed"
+    Rini= 0.; Rend= 0.;
+    (Rini,Rend,DXCsm,DYCsm)=demo2();
+    @test isa(Rini,gcmfaces)
+    Sini=sqrt(sum(Rini*Rini)/(Npt-1.0))
+    Send=sqrt(sum(Rend*Rend)/(Npt-1.0))
+    #println([Sini Send])
+    @test isapprox(Sini,1.000; atol=1e-2)
+    @test isapprox(Send,0.093; atol=1e-2)
+end;
+


### PR DESCRIPTION
- Project.toml: add extras and targets for Test as needed for package testing;
- runtests.jl: setup an actual series of tests based on GCMGridOnes and demo2;
- gcmfaces_grids.jl: replace println with return of a String (used for testing)
   in GCMGrid*; adjust indentation per JuliaLang's CONTRIBUTING.md (4 spaces).
- src/gcmfaces_calc.jl: comment out print statement ("nbt in smooth="*"$nbt").
- .travis.yml (new): CI tests for v0.7, v1.0, and nightly on linux and osx
- README.md: add badges from travis, codecov, and coveralls
