### PR TITLE
rewrite exchange methods and streamline operations to improve performance

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MeshArrays"
 uuid = "28126448-9d44-11e8-08f5-e59c47736fcb"
 authors = ["gaelforget <gforget@mit.edu>"]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"

--- a/src/MeshArrays.jl
+++ b/src/MeshArrays.jl
@@ -12,7 +12,7 @@ include("gcmfaces_convert.jl");
 include("gcmfaces_IO.jl");
 include("gcmfaces_demo.jl");
 
-export gcmfaces, exchange, gradient, smooth, mask, fsize
+export gcmfaces, exchange, gradient, convergence, smooth, mask, fsize
 export GCMGridSpec, GCMGridLoad, GCMGridOnes
 export demo1, demo2
 #The following functions rely on grid specs; currently via global vars.

--- a/src/gcmfaces_calc.jl
+++ b/src/gcmfaces_calc.jl
@@ -1,108 +1,170 @@
 
-function gradient(fld)
+## gradient methods
 
-  FLD=exchange(fld,1);
-
-  dFLDdx=gcmfaces(fld.nFaces,fld.grTopo);
-  dFLDdy=gcmfaces(fld.nFaces,fld.grTopo);
-  for iFace=1:FLD.nFaces;
-     tmpA=FLD.f[iFace][2:end-1,2:end-1];
-     tmpB=FLD.f[iFace][1:end-2,2:end-1];
-     dFLDdx.f[iFace]=(tmpA-tmpB)./MeshArrays.DXC.f[iFace];
-     tmpA=FLD.f[iFace][2:end-1,2:end-1];
-     tmpB=FLD.f[iFace][2:end-1,1:end-2];
-     dFLDdy.f[iFace]=(tmpA-tmpB)./MeshArrays.DYC.f[iFace];
-  end;
-
-  return dFLDdx, dFLDdy
-
+function gradient(inFLD::gcmfaces)
+(dFLDdx, dFLDdy)=gradient(inFLD,true)
+return dFLDdx, dFLDdy
 end
 
-##
+function gradient(inFLD::gcmfaces,doDIV::Bool)
+
+exFLD=exchange(inFLD,1)
+dFLDdx=gcmfaces(inFLD.nFaces,inFLD.grTopo)
+dFLDdy=gcmfaces(inFLD.nFaces,inFLD.grTopo)
+
+for a=1:inFLD.nFaces;
+  (s1,s2)=fsize(exFLD,a)
+  tmpA=view(exFLD.f[a],2:s1-1,2:s2-1)
+  tmpB=tmpA-view(exFLD.f[a],1:s1-2,2:s2-1)
+  tmpC=tmpA-view(exFLD.f[a],2:s1-1,1:s2-2)
+  if doDIV
+    dFLDdx.f[a]=tmpB./MeshArrays.DXC.f[a]
+    dFLDdy.f[a]=tmpC./MeshArrays.DYC.f[a]
+  else
+    dFLDdx.f[a]=tmpB
+    dFLDdy.f[a]=tmpC
+  end
+end
+
+return dFLDdx, dFLDdy
+end
+
+function gradient(inFLD::gcmfaces,iDXC::gcmfaces,iDYC::gcmfaces)
+
+exFLD=exchange(inFLD,1)
+dFLDdx=gcmfaces(inFLD.nFaces,inFLD.grTopo)
+dFLDdy=gcmfaces(inFLD.nFaces,inFLD.grTopo)
+
+for a=1:inFLD.nFaces;
+  (s1,s2)=fsize(exFLD,a)
+  tmpA=view(exFLD.f[a],2:s1-1,2:s2-1)
+  tmpB=tmpA-view(exFLD.f[a],1:s1-2,2:s2-1)
+  tmpC=tmpA-view(exFLD.f[a],2:s1-1,1:s2-2)
+  dFLDdx.f[a]=tmpB.*iDXC.f[a]
+  dFLDdy.f[a]=tmpC.*iDYC.f[a]
+end
+
+return dFLDdx, dFLDdy
+end
+
+## mask methods
 
 function mask(fld::gcmfaces)
-  fldmsk=mask(fld,(NaN,Inf,0.),NaN)
-  return fldmsk
+fldmsk=mask(fld,NaN)
+return fldmsk
 end
 
 function mask(fld::gcmfaces, val::Number)
-  fldmsk=mask(fld,(NaN,Inf,0.),val)
-  return fldmsk
-end
-
-function mask(fld::gcmfaces, cond::Number, val::Number)
-  fldmsk=mask(fld,(cond,),val)
-  return fldmsk
-end
-
-function mask(fld::gcmfaces,cond::Tuple,val::Number)
-
-  fldmsk=gcmfaces(fld.nFaces,fld.grTopo);
-
-  for iFace=1:fld.nFaces;
-     tmp1=fld.f[iFace]
-     for i=1:length(cond)
-       isnan(cond[i]) ? tmp1[findall(isnan.(tmp1))] .= val : nothing
-       isinf(cond[i]) ? tmp1[findall(isinf.(tmp1))] .= val : nothing
-       isfinite(cond[i]) ? tmp1[findall(tmp1 .== cond[i])] .= val : nothing
-     end
-     fldmsk.f[iFace]=tmp1
+  fldmsk=gcmfaces(fld.nFaces,fld.grTopo)
+  for a=1:fld.nFaces
+    tmp1=copy(fld.f[a])
+    replace!(x -> !isfinite(x) ? val : x, tmp1 )
+    fldmsk.f[a]=tmp1
   end
-
   return fldmsk
-
 end
 
-##
+function mask(fld::gcmfaces, val::Number, noval::Number)
+  fldmsk=gcmfaces(fld.nFaces,fld.grTopo)
+  for a=1:fld.nFaces
+    tmp1=copy(fld.f[a])
+    replace!(x -> x==noval ? val : x, tmp1  )
+    fldmsk.f[a]=tmp1
+  end
+  return fldmsk
+end
 
-function smooth(fld::gcmfaces,DXCsm::gcmfaces,DYCsm::gcmfaces)
+## convergence methods
 
-#get land mask:
-msk=fill(1.,fld) + 0. * mask(fld,NaN);
+function convergence(uFLD::gcmfaces,vFLD::gcmfaces);
+
+#important note:
+#  Normally uFLD, vFLD should not contain any NaN;
+#  if otherwise then something this may be needed:
+#  uFLD=mask(uFLD,0.0); vFLD=mask(vFLD,0.0);
+
+CONV=gcmfaces(uFLD.nFaces,uFLD.grTopo)
+
+(tmpU,tmpV)=exch_UV(uFLD,vFLD)
+for a=1:tmpU.nFaces
+  (s1,s2)=fsize(uFLD,a)
+  tmpU1=view(tmpU.f[a],1:s1,1:s2)
+  tmpU2=view(tmpU.f[a],2:s1+1,1:s2)
+  tmpV1=view(tmpV.f[a],1:s1,1:s2)
+  tmpV2=view(tmpV.f[a],1:s1,2:s2+1)
+  CONV.f[a]=tmpU1-tmpU2+tmpV1-tmpV2
+end
+
+return CONV
+end
+
+## smooth function
+
+function smooth(FLD::gcmfaces,DXCsm::gcmfaces,DYCsm::gcmfaces)
+
+#important note:
+#input FLD should be land masked (NaN/1) by caller if needed
+
+#get land masks (NaN/1):
+mskC=fill(1.0,FLD) + 0.0 * mask(FLD)
+(mskW,mskS)=gradient(FLD,false)
+mskW=fill(1.0,FLD) + 0.0 * mask(mskW)
+mskS=fill(1.0,FLD) + 0.0 * mask(mskS)
+
+#replace NaN with 0. in FLD and land masks:
+FLD=mask(FLD,0.0)
+mskC=mask(mskC,0.0)
+mskW=mask(mskW,0.0)
+mskS=mask(mskS,0.0)
+
+#get inverse grid spacing:
+iDXC=gcmfaces(FLD.nFaces,FLD.grTopo)
+iDYC=gcmfaces(FLD.nFaces,FLD.grTopo)
+for a=1:FLD.nFaces;
+  iDXC.f[a]=1.0./MeshArrays.DXC.f[a]
+  iDYC.f[a]=1.0./MeshArrays.DYC.f[a]
+end
 
 #Before scaling the diffusive operator ...
-tmp0=DXCsm/MeshArrays.DXC;
-tmp0=mask(msk*tmp0,0.);
+tmp0=DXCsm*iDXC*mskW;
 tmp00=maximum(tmp0);
-tmp0=DYCsm/MeshArrays.DYC;
-tmp0=mask(msk*tmp0,0.);
+tmp0=DYCsm*iDYC*mskS;
 tmp00=max(tmp00,maximum(tmp0));
 
 #... determine a suitable time period:
 nbt=ceil(1.1*2*tmp00^2);
 dt=1.;
 T=nbt*dt;
+#println("nbt="*"$nbt")
 
-#diffusion operator:
-Kux=DXCsm*DXCsm/T/2;
-Kvy=DYCsm*DYCsm/T/2;
+#diffusion operator times DYG / DXG:
+KuxFac=mskW*DXCsm*DXCsm/T/2.0*MeshArrays.DYG;
+KvyFac=mskS*DYCsm*DYCsm/T/2.0*MeshArrays.DXG;
+
+#time steping factor:
+dtFac=dt*mskC/MeshArrays.RAC;
 
 #loop:
 for it=1:nbt
-  (dTdxAtU,dTdyAtV)=gradient(fld);
-  tmpU=dTdxAtU*Kux*MeshArrays.DYG;
-  tmpV=dTdyAtV*Kvy*MeshArrays.DXG;
+  (dTdxAtU,dTdyAtV)=gradient(FLD,iDXC,iDYC);
+  tmpU=gcmfaces(FLD.nFaces,FLD.grTopo)
+  tmpV=gcmfaces(FLD.nFaces,FLD.grTopo)
+  for a=1:FLD.nFaces
+      tmpU.f[a]=dTdxAtU.f[a].*KuxFac.f[a];
+      tmpV.f[a]=dTdyAtV.f[a].*KvyFac.f[a];
+  end
   tmpC=convergence(tmpU,tmpV);
-  fld=fld-dt*msk*tmpC/MeshArrays.RAC;
+  for a=1:FLD.nFaces
+      FLD.f[a]=FLD.f[a]-dtFac.f[a].*tmpC.f[a];
+  end
 end
 
-return fld
+#Apply land mask (NaN/1) to end result:
+mskC=mask(mskC,NaN,0.0)
+FLD=mskC*FLD
+
+return FLD
 
 end
 
 ##
-
-function convergence(fldU::gcmfaces,fldV::gcmfaces);
-
-  (tmpU,tmpV)=exch_UV(fldU,fldV);
-  tmpU=mask(tmpU,NaN,0);
-  tmpV=mask(tmpV,NaN,0);
-  tmpC=gcmfaces(tmpU.nFaces,tmpU.grTopo);
-  for iFace=1:tmpU.nFaces;
-    tmp1=tmpU.f[iFace][1:end-1,:,:,:]-tmpU.f[iFace][2:end,:,:,:];
-    tmp2=tmpV.f[iFace][:,1:end-1,:,:]-tmpV.f[iFace][:,2:end,:,:];
-    tmpC.f[iFace]=dropdims(tmp1+tmp2,dims=(3,4));
-  end;
-  return tmpC
-
-end

--- a/src/gcmfaces_demo.jl
+++ b/src/gcmfaces_demo.jl
@@ -63,9 +63,9 @@ Rini=convert2gcmfaces(tmp1);
 
 #apply land mask
 if ndims(MeshArrays.hFacC.f[1])>2
-    tmp1=mask(view(MeshArrays.hFacC,:,:,1),NaN);
+    tmp1=mask(view(MeshArrays.hFacC,:,:,1),NaN,0);
 else
-    tmp1=mask(MeshArrays.hFacC,NaN);
+    tmp1=mask(MeshArrays.hFacC,NaN,0);
 end
 msk=fill(1.,tmp1) + 0. *tmp1;
 Rini=msk*Rini;

--- a/src/gcmfaces_exch.jl
+++ b/src/gcmfaces_exch.jl
@@ -1,17 +1,8 @@
 
-## This file contains the following methods:
-# exchange.jl
-# exch_T_N.jl
-# exch_T_N_llc.jl
-# exch_T_N_cs.jl
-# exch_T_N_ll.jl
+## This file contains the exchange and exch_UV functions
+# along with grid-specific methods (exch_T_N.jl, etc.)
 
-#Correspondance to Matlab sym_g are as follows:
-#5	rotl90
-#6	rot180
-#7	rotr90
-
-## user front end
+## User Front Ends
 
 function exchange(fld::gcmfaces)
   FLD=exch_T_N(fld,1);
@@ -31,10 +22,12 @@ end
 
 ## dispatch over grid types
 
+#note: the "cs" implementation covers both cs and llc
+
 function exch_T_N(fld,N)
 
 if fld.grTopo=="llc";
-  FLD=exch_T_N_llc(fld,N);
+  FLD=exch_T_N_cs(fld,N);
 elseif fld.grTopo=="cs";
   FLD=exch_T_N_cs(fld,N);
 elseif fld.grTopo=="ll";
@@ -47,26 +40,10 @@ FLD
 
 end
 
-function exch_UV(u,v)
-
-if u.grTopo=="llc";
-  (uex,vex)=exch_UV_llc(u,v);
-elseif u.grTopo=="cs";
-  (uex,vex)=exch_UV_cs(u,v);
-elseif u.grTopo=="ll";
-  (uex,vex)=exch_UV_ll(u,v);
-else;
-  error("unknown grTopo case");
-end;
-
-return uex,vex
-
-end
-
 function exch_UV_N(u,v,N)
 
 if u.grTopo=="llc";
-  (uex,vex)=exch_UV_N_llc(u,v,N);
+  (uex,vex)=exch_UV_N_cs(u,v,N);
 elseif u.grTopo=="cs";
   (uex,vex)=exch_UV_N_cs(u,v,N);
 elseif u.grTopo=="ll";
@@ -79,571 +56,287 @@ return uex,vex
 
 end
 
-## Grid-specific implementations
+function exch_UV(u,v)
 
-function exch_T_N_ll(fld,N)
+if u.grTopo=="llc";
+  (uex,vex)=exch_UV_cs(u,v);
+elseif u.grTopo=="cs";
+  (uex,vex)=exch_UV_cs(u,v);
+elseif u.grTopo=="ll";
+  (uex,vex)=exch_UV_ll(u,v);
+else;
+  error("unknown grTopo case");
+end;
 
-s=size(fld.f[1]); s=[i for i in s]; s[1:2]=s[1:2].+2*N;
-f1=NaN*zeros(Float32,s[1],s[2]);
-f1=zeros(Float32,s[1],s[2]);
-FLD=gcmfaces(1,"ll",[f1]);
-
-n3=max(size(fld.f[1],3),1); n4=max(size(fld.f[1],4),1);
-
-#initial rotation for "LATLON" faces:
-f1=copy(fld.f[1]);
-
-#nan0=NaN*ones(N,size(fld.f[1],2),n3,n4);
-nan0=NaN*ones(size(FLD.f[1],1),N,n3,n4);
-
-#face 1:
-F1=cat(f1[end-N+1:end,:,:,:],f1,f1[1:N,:,:,:];dims=1);
-F1=cat(nan0,F1,nan0;dims=2);
-#F1=copy(nan0);
-
-F1=dropdims(F1,dims=(3,4));
-
-#store:
-FLD.f[1]=F1;
-
-FLD
+return uex,vex
 
 end
 
-#
+## Grid-specific implementations: ll grid case
 
-function exch_T_N_llc(fld,N)
+function exch_T_N_ll(fld::gcmfaces,N::Integer)
 
-s=size(fld.f[1]); s=[i for i in s]; s[1:2]=s[1:2].+2*N; f1=NaN*zeros(s[1],s[2]);
-s=size(fld.f[2]); s=[i for i in s]; s[1:2]=s[1:2].+2*N; f2=NaN*zeros(s[1],s[2]);
-s=size(fld.f[3]); s=[i for i in s]; s[1:2]=s[1:2].+2*N; f3=NaN*zeros(s[1],s[2]);
-s=size(fld.f[4]); s=[i for i in s]; s[1:2]=s[1:2].+2*N; f4=NaN*zeros(s[1],s[2]);
-s=size(fld.f[5]); s=[i for i in s]; s[1:2]=s[1:2].+2*N; f5=NaN*zeros(s[1],s[2]);
-FLD=gcmfaces(5,"llc",[f1,f2,f3,f4,f5]);
+fillval=0.0
 
-n3=max(size(fld.f[1],3),1); n4=max(size(fld.f[1],4),1);
+#step 1
 
-#initial rotation for "LATLON" faces:
-f1=copy(fld.f[1]);
-f2=copy(fld.f[2]);
-f4=rotr90(fld.f[4]);
-f5=rotr90(fld.f[5]);
+s=size.(fld.f);
+FLD=gcmfaces(1,"ll");
+FLD.f[1]=fill(fillval,s[1].+2N);
+@views FLD.f[1][N+1:N+s[1][1],N+1:N+s[1][2]]=fld.f[1];
 
-nan1=NaN*ones(size(FLD.f[1],1),N,n3,n4);
-nan2=NaN*ones(N,N,n3,n4);
-#face 1:
-F1=cat(f5[end-N+1:end,:,:,:],f1,f2[1:N,:,:,:];dims=1);
-f3=rotl90(copy(fld.f[3]));
-F1=cat(nan1,F1,cat(nan2,f3[:,1:N,:,:],nan2;dims=1);dims=2);
-#face 2:
-F2=cat(f1[end-N+1:end,:,:,:],f2,f4[1:N,:,:,:];dims=1);
-f3=copy(fld.f[3]);
-F2=cat(nan1,F2,cat(nan2,f3[:,1:N,:,:],nan2;dims=1);dims=2);
-#face 4:
-F4=cat(f2[end-N+1:end,:,:,:],f4,f5[1:N,:,:,:];dims=1);
-f3=rotr90(copy(fld.f[3]));
-F4=cat(nan1,F4,cat(nan2,f3[:,1:N,:,:],nan2;dims=1);dims=2);
-#face 5:
-F5=cat(f4[end-N+1:end,:,:,:],f5,f1[1:N,:,:,:];dims=1);
-f3=rot180(copy(fld.f[3]));
-F5=cat(nan1,F5,cat(nan2,f3[:,1:N,:,:],nan2;dims=1);dims=2);
-#face 3:
-f3=copy(fld.f[3]); F3=FLD.f[3];
-F3[1+N:end-N,1+N:end-N,:,:]=f3;
-F3=rotl90(F3); F3[1+N:end-N,1:N,:,:]=f1[:,end-N+1:end,:,:]; F3=rotr90(F3);
-F3[1+N:end-N,1:N,:,:]=f2[:,end-N+1:end,:,:];
-F3=rotr90(F3); F3[1+N:end-N,1:N,:,:]=f4[:,end-N+1:end,:,:]; F3=rotl90(F3);
-F3=rot180(F3); F3[1+N:end-N,1:N,:,:]=f5[:,end-N+1:end,:,:]; F3=rot180(F3);
+#step 2
 
-F1=dropdims(F1,dims=(3,4));
-F2=dropdims(F2,dims=(3,4));
-#F3=dropdims(F3,dims=(3,4));
-F4=dropdims(F4,dims=(3,4));
-F5=dropdims(F5,dims=(3,4));
+iW=(s[1][1]-N+1:s[1][1],1:s[1][2]);
+iE=(1:N,1:s[1][2]);
+jW=(1:N,N+1:N+s[1][2]);
+jE=(N+1+s[1][1]:2N+s[1][1],N+1:N+s[1][2]);
+FLD.f[1][jW[1],jW[2]]=view(fld.f[1],iW[1],iW[2])
+FLD.f[1][jE[1],jE[2]]=view(fld.f[1],iE[1],iE[2])
 
-#final rotation for "LATLON" faces:
-F4=rotl90(F4);
-F5=rotl90(F5);
-
-#store:
-FLD.f[1]=F1;
-FLD.f[2]=F2;
-FLD.f[3]=F3;
-FLD.f[4]=F4;
-FLD.f[5]=F5;
-
-FLD
+return FLD
 
 end
 
-#
-
-function exch_T_N_cs(fld,N)
-
-s=size(fld.f[1]); s=[i for i in s]; s[1:2]=s[1:2].+2*N; f1=NaN*zeros(s[1],s[2]);
-s=size(fld.f[2]); s=[i for i in s]; s[1:2]=s[1:2].+2*N; f2=NaN*zeros(s[1],s[2]);
-s=size(fld.f[3]); s=[i for i in s]; s[1:2]=s[1:2].+2*N; f3=NaN*zeros(s[1],s[2]);
-s=size(fld.f[4]); s=[i for i in s]; s[1:2]=s[1:2].+2*N; f4=NaN*zeros(s[1],s[2]);
-s=size(fld.f[5]); s=[i for i in s]; s[1:2]=s[1:2].+2*N; f5=NaN*zeros(s[1],s[2]);
-s=size(fld.f[6]); s=[i for i in s]; s[1:2]=s[1:2].+2*N; f6=NaN*zeros(s[1],s[2]);
-FLD=gcmfaces(6,"cs",[f1,f2,f3,f4,f5,f6]);
-
-n3=max(size(fld.f[1],3),1); n4=max(size(fld.f[1],4),1);
-
-#initial rotation for "LATLON" faces:
-f1=copy(fld.f[1]);
-f2=copy(fld.f[2]);
-f4=rotr90(fld.f[4]);
-f5=rotr90(fld.f[5]);
-
-nan1=NaN*ones(size(FLD.f[1],1),N,n3,n4);
-nan2=NaN*ones(N,N,n3,n4);
-#face 1:
-F1=cat(f5[end-N+1:end,:,:,:],f1,f2[1:N,:,:,:];dims=1);
-f3=rotl90(copy(fld.f[3]));
-f6=copy(fld.f[6]);
-F1=cat(cat(nan2,f6[:,end-N+1:end,:,:],nan2;dims=1),F1,cat(nan2,f3[:,1:N,:,:],nan2;dims=1);dims=2);
-#face 2:
-F2=cat(f1[end-N+1:end,:,:,:],f2,f4[1:N,:,:,:];dims=1);
-f3=copy(fld.f[3]);
-f6=rotl90(copy(fld.f[6]));
-F2=cat(cat(nan2,f6[:,end-N+1:end,:,:],nan2;dims=1),F2,cat(nan2,f3[:,1:N,:,:],nan2;dims=1);dims=2);
-#face 4:
-F4=cat(f2[end-N+1:end,:,:,:],f4,f5[1:N,:,:,:];dims=1);
-f3=rotr90(copy(fld.f[3]));
-f6=rot180(copy(fld.f[6]));
-F4=cat(cat(nan2,f6[:,end-N+1:end,:,:],nan2;dims=1),F4,cat(nan2,f3[:,1:N,:,:],nan2;dims=1);dims=2);
-#face 5:
-F5=cat(f4[end-N+1:end,:,:,:],f5,f1[1:N,:,:,:];dims=1);
-f3=rot180(copy(fld.f[3]));
-f6=rotr90(copy(fld.f[6]));
-F5=cat(cat(nan2,f6[:,end-N+1:end,:,:],nan2;dims=1),F5,cat(nan2,f3[:,1:N,:,:],nan2;dims=1);dims=2);
-#face 3:
-f3=copy(fld.f[3]); F3=FLD.f[3];
-F3[1+N:end-N,1+N:end-N,:,:]=f3;
-F3=rotl90(F3); F3[1+N:end-N,1:N,:,:]=f1[:,end-N+1:end,:,:]; F3=rotr90(F3);
-F3[1+N:end-N,1:N,:,:]=f2[:,end-N+1:end,:,:];
-F3=rotr90(F3); F3[1+N:end-N,1:N,:,:]=f4[:,end-N+1:end,:,:]; F3=rotl90(F3);
-F3=rot180(F3); F3[1+N:end-N,1:N,:,:]=f5[:,end-N+1:end,:,:]; F3=rot180(F3);
-#face 6:
-f6=copy(fld.f[6]); F6=FLD.f[6];
-F6[1+N:end-N,1+N:end-N,:,:]=f6;
-F6[1+N:end-N,end-N+1:end,:,:]=f1[:,1:N,:,:];
-F6=rotl90(F6); F6[1+N:end-N,end-N+1:end,:,:]=f2[:,1:N,:,:]; F6=rotr90(F6);
-F6=rot180(F6); F6[1+N:end-N,end-N+1:end,:,:]=f4[:,1:N,:,:]; F6=rot180(F6);
-F6=rotr90(F6); F6[1+N:end-N,end-N+1:end,:,:]=f5[:,1:N,:,:]; F6=rotl90(F6);
-
-F1=dropdims(F1,dims=(3,4));
-F2=dropdims(F2,dims=(3,4));
-#F3=dropdims(F3,dims=(3,4));
-F4=dropdims(F4,dims=(3,4));
-F5=dropdims(F5,dims=(3,4));
-#F6=dropdims(F6,dims=(3,4));
-
-#final rotation for "SIDE" faces:
-F4=rotl90(F4);
-F5=rotl90(F5);
-
-#store:
-FLD.f[1]=F1;
-FLD.f[2]=F2;
-FLD.f[3]=F3;
-FLD.f[4]=F4;
-FLD.f[5]=F5;
-FLD.f[6]=F6;
-
-FLD
-
-end
-
-## function that extends U,V in one direction each
-
-function exch_UV_ll(fldU,fldV);
-
-FLDUtmp=exchange(fldU);
-FLDVtmp=exchange(fldV);
-
-FLDU=exchange(fldU);
-FLDV=exchange(fldV);
-
-FLDU.f[1]=FLDUtmp.f[1][2:end,2:end-1];
-FLDV.f[1]=FLDVtmp.f[1][2:end-1,2:end];
-
-return FLDU,FLDV
-
-end
-
-
-function exch_UV_llc(fldU,fldV);
-
-FLDUtmp=exchange(fldU);
-FLDVtmp=exchange(fldV);
-
-FLDU=exchange(fldU);
-FLDV=exchange(fldV);
-
-FLDU.f[1]=FLDUtmp.f[1][2:end,2:end-1];
-FLDV.f[1]=FLDVtmp.f[1][2:end-1,2:end];
-FLDV.f[1][:,end]=FLDUtmp.f[1][2:end-1,end];
-
-FLDU.f[2]=FLDUtmp.f[2][2:end,2:end-1];
-FLDU.f[2][end,:]=FLDVtmp.f[2][end,2:end-1];
-FLDV.f[2]=FLDVtmp.f[2][2:end-1,2:end];
-
-FLDU.f[3]=FLDUtmp.f[3][2:end,2:end-1];
-FLDV.f[3]=FLDVtmp.f[3][2:end-1,2:end];
-FLDV.f[3][:,end]=FLDUtmp.f[3][2:end-1,end];
-
-FLDU.f[4]=FLDUtmp.f[4][2:end,2:end-1];
-FLDV.f[4]=FLDVtmp.f[4][2:end-1,2:end];
-
-FLDU.f[5]=FLDUtmp.f[5][2:end,2:end-1];
-FLDV.f[5]=FLDVtmp.f[5][2:end-1,2:end];
-FLDV.f[5][:,end]=FLDUtmp.f[5][2:end-1,end];
-
-return FLDU,FLDV
-
-end
-
-#
-
-function exch_UV_cs(fldU,fldV);
-
-#!! this differs from regular exhange that adds
-#points on all sides -- this just adds one point
-#at end of one direction (U or V)
-#
-#should utlimately be avoided, in favor of
-#exch_UV_N_cs, to keep things simple throughout?
-
-FLDUtmp=exchange(fldU);
-FLDVtmp=exchange(fldV);
-
-FLDU=exchange(fldU);
-FLDV=exchange(fldV);
-
-FLDU.f[1]=FLDUtmp.f[1][2:end,2:end-1];
-FLDV.f[1]=FLDVtmp.f[1][2:end-1,2:end];
-FLDV.f[1][:,end]=FLDUtmp.f[1][2:end-1,end];
-
-FLDU.f[2]=FLDUtmp.f[2][2:end,2:end-1];
-FLDU.f[2][end,:]=FLDVtmp.f[2][end,2:end-1];
-FLDV.f[2]=FLDVtmp.f[2][2:end-1,2:end];
-
-FLDU.f[3]=FLDUtmp.f[3][2:end,2:end-1];
-FLDV.f[3]=FLDVtmp.f[3][2:end-1,2:end];
-FLDV.f[3][:,end]=FLDUtmp.f[3][2:end-1,end];
-
-FLDU.f[4]=FLDUtmp.f[4][2:end,2:end-1];
-FLDU.f[4][end,:]=FLDVtmp.f[4][end,2:end-1];
-FLDV.f[4]=FLDVtmp.f[4][2:end-1,2:end];
-#?? u
-
-FLDU.f[5]=FLDUtmp.f[5][2:end,2:end-1];
-FLDV.f[5]=FLDVtmp.f[5][2:end-1,2:end];
-FLDV.f[5][:,end]=FLDUtmp.f[5][2:end-1,end];
-
-FLDU.f[6]=FLDUtmp.f[6][2:end,2:end-1];
-FLDU.f[6][end,:]=FLDVtmp.f[6][end,2:end-1];
-FLDV.f[6]=FLDVtmp.f[6][2:end-1,2:end];
-#??u
-
-return FLDU,FLDV
-
-end
-
-## function that extends U, V by N points on all sides
+##
 
 function exch_UV_N_ll(fldU,fldV,N);
 
-FLDU=exchange(fldU,N);
-FLDV=exchange(fldV,N);
+FLDU=exch_T_N_ll(fldU,N);
+FLDV=exch_T_N_ll(fldV,N);
 
 return FLDU,FLDV
 
 end
 
-#
+##
 
-function exch_UV_N_llc(fldU,fldV,N);
+function exch_UV_ll(fldU,fldV);
 
-#fill interior of extended arrays
-FLDUtmp=exch_T_N(fldU,N); FLDVtmp=exch_T_N(fldV,N);
-for iFace=1:fldU.nFaces;
-    FLDUtmp.f[iFace][1:N,:].=NaN;
-    FLDUtmp.f[iFace][end-N+1:end,:].=NaN;
-    FLDUtmp.f[iFace][:,1:N].=NaN;
-    FLDUtmp.f[iFace][:,end-N+1:end].=NaN;
-    FLDVtmp.f[iFace][1:N,:].=NaN;
-    FLDVtmp.f[iFace][end-N+1:end,:].=NaN;
-    FLDVtmp.f[iFace][:,1:N].=NaN;
-    FLDVtmp.f[iFace][:,end-N+1:end].=NaN;
-end;
+fillval=0.0
 
-FLDU=FLDUtmp;
-FLDV=FLDVtmp;
+#step 1
 
-#now add the one extra point we need for U and V
-(FLDUtmp,FLDVtmp)=exch_UV_llc(fldU,fldV);
-#then add the remaining rows and columns...
+s=size.(fldU.f);
+FLDU=gcmfaces(1,"ll");
+FLDV=gcmfaces(1,"ll");
 
-#U face 1
-tmp1=permutedims(FLDVtmp.f[5][:,end-N:end-1,:],[2 1 3]);
-FLDU.f[1][1:N,N+1:end-N]=reverse(tmp1,dims=2);
-tmp1=FLDUtmp.f[2][1:N,:];
-FLDU.f[1][end-N+1:end,N+1:end-N]=tmp1;
-#
-tmp1=permutedims(-FLDVtmp.f[3][1:N,:,:],[2 1 3]);
-FLDU.f[1][N+1:end-N+1,end-N+1:end]=reverse(tmp1,dims=1);
+FLDU.f[1]=fill(fillval,s[1][1]+1,s[1][2]);
+FLDV.f[1]=fill(fillval,s[1][1],s[1][2]+1);
+@views FLDU.f[1][1:s[1][1],1:s[1][2]]=fldU.f[1];
+@views FLDV.f[1][1:s[1][1],1:s[1][2]]=fldV.f[1];
 
-#V face 1
-tmp1=permutedims(-FLDUtmp.f[5][:,end-N+1:end,:],[2 1 3]);
-FLDV.f[1][1:N,N+1:end-N+1]=reverse(tmp1,dims=2);
-tmp1=FLDVtmp.f[2][1:N,:];
-FLDV.f[1][end-N+1:end,N+1:end-N+1]=tmp1;
-#
-tmp1=permutedims(FLDUtmp.f[3][1:N,:,:],[2 1 3]);
-FLDV.f[1][N+1:end-N,end-N+1:end]=reverse(tmp1,dims=1);
+#step 2
 
-#U face 2
-tmp1=FLDUtmp.f[1][end-N:end-1,:];
-FLDU.f[2][1:N,N+1:end-N]=tmp1;
-tmp1=permutedims(FLDVtmp.f[4][:,1:N,:],[2 1 3]);
-FLDU.f[2][end-N+1:end,N+1:end-N]=reverse(tmp1,dims=2);
-#
-tmp1=FLDUtmp.f[3][:,1:N];
-FLDU.f[2][N+1:end-N+1,end-N+1:end]=tmp1;
-
-#V face 2
-tmp1=FLDVtmp.f[1][end-N+1:end,:];
-FLDV.f[2][1:N,N+1:end-N+1]=tmp1;
-tmp1=permutedims(-FLDUtmp.f[4][:,1:N,:],[2 1 3]);
-FLDV.f[2][end-N+1:end,N+1:end-N+1]=reverse(tmp1,dims=2);
-#
-tmp1=FLDVtmp.f[3][:,1:N];
-FLDV.f[2][N+1:end-N,end-N+1:end]=tmp1;
-
-#U face 3
-tmp1=permutedims(FLDVtmp.f[1][:,end-N:end-1,:],[2 1 3]);
-FLDU.f[3][1:N,N+1:end-N]=reverse(tmp1,dims=2);
-tmp1=FLDUtmp.f[4][1:N,:];
-FLDU.f[3][end-N+1:end,N+1:end-N]=tmp1;
-#
-tmp1=FLDUtmp.f[2][:,end-N+1:end];
-FLDU.f[3][N+1:end-N+1,1:N]=tmp1;
-tmp1=permutedims(-FLDVtmp.f[5][1:N,:,:],[2 1 3]);
-FLDU.f[3][N+1:end-N+1,end-N+1:end]=reverse(tmp1,dims=1);
-
-#V face 3
-tmp1=permutedims(-FLDUtmp.f[1][:,end-N+1:end,:],[2 1 3]);
-FLDV.f[3][1:N,N+1:end-N+1]=reverse(tmp1,dims=2);
-tmp1=FLDVtmp.f[4][1:N,:];
-FLDV.f[3][end-N+1:end,N+1:end-N+1]=tmp1;
-#
-tmp1=FLDVtmp.f[2][:,end-N:end-1];
-FLDV.f[3][N+1:end-N,1:N]=tmp1;
-tmp1=permutedims(FLDUtmp.f[5][1:N,:,:],[2 1 3]);
-FLDV.f[3][N+1:end-N,end-N+1:end]=reverse(tmp1,dims=1);
-
-#U face 4
-tmp1=FLDUtmp.f[3][end-N:end-1,:];
-FLDU.f[4][1:N,N+1:end-N]=tmp1;
-#
-tmp1=permutedims(-FLDVtmp.f[2][end-N+1:end,:,:],[2 1 3]);
-FLDU.f[4][N+1:end-N+1,1:N]=reverse(tmp1,dims=1);
-tmp1=FLDUtmp.f[5][:,1:N];
-FLDU.f[4][N+1:end-N+1,end-N+1:end]=tmp1;
-
-#V face 4
-tmp1=FLDVtmp.f[3][end-N+1:end,:];
-FLDV.f[4][1:N,N+1:end-N+1]=tmp1;
-#
-tmp1=permutedims(FLDUtmp.f[2][end-N:end-1,:,:],[2 1 3]);
-FLDV.f[4][N+1:end-N,1:N]=reverse(tmp1,dims=1);
-tmp1=FLDVtmp.f[5][:,1:N];
-FLDV.f[4][N+1:end-N,end-N+1:end]=tmp1;
-
-#U face 5
-tmp1=permutedims(FLDVtmp.f[3][:,end-N:end-1,:],[2 1 3]);
-FLDU.f[5][1:N,N+1:end-N]=reverse(tmp1,dims=2);
-#
-tmp1=FLDUtmp.f[4][:,end-N+1:end];
-FLDU.f[5][N+1:end-N+1,1:N]=tmp1;
-tmp1=permutedims(-FLDVtmp.f[1][1:N,:,:],[2 1 3]);
-FLDU.f[5][N+1:end-N+1,end-N+1:end]=reverse(tmp1,dims=1);
-
-#V face 5
-tmp1=permutedims(-FLDUtmp.f[3][:,end-N+1:end,:],[2 1 3]);
-FLDV.f[5][1:N,N+1:end-N+1]=reverse(tmp1,dims=2);
-#
-tmp1=FLDVtmp.f[4][:,end-N:end-1];
-FLDV.f[5][N+1:end-N,1:N]=tmp1;
-tmp1=permutedims(FLDUtmp.f[1][1:N,:,:],[2 1 3]);
-FLDV.f[5][N+1:end-N,end-N+1:end]=reverse(tmp1,dims=1);
+FLDU.f[1][s[1][1]+1,1:s[1][2]]=view(fldU.f[1],1,1:s[1][2])
 
 return FLDU,FLDV
 
 end
 
-#
+## Grid-specific implementations: cs & llc grid case
 
-function exch_UV_N_cs(fldU,fldV,N);
+#note: the "cs" implementation covers both cs and llc
 
-#fill interior of extended arrays
-FLDUtmp=exchange(fldU,N);
-FLDVtmp=exchange(fldV,N);
-for iFace=1:fldU.nFaces;
-    FLDUtmp.f[iFace][1:N,:,:].=NaN;
-    FLDUtmp.f[iFace][end-N+1:end,:,:].=NaN;
-    FLDUtmp.f[iFace][:,1:N,:].=NaN;
-    FLDUtmp.f[iFace][:,end-N+1:end,:].=NaN;
-    FLDVtmp.f[iFace][1:N,:,:].=NaN;
-    FLDVtmp.f[iFace][end-N+1:end,:,:].=NaN;
-    FLDVtmp.f[iFace][:,1:N,:].=NaN;
-    FLDVtmp.f[iFace][:,end-N+1:end,:].=NaN;
+function exch_T_N_cs(fld::gcmfaces,N::Integer)
+
+fillval=0.0
+
+#step 1
+
+s=size.(fld.f);
+nf=fld.nFaces;
+nf==5 ? s=vcat(s,s[3]) : nothing
+tp=fld.grTopo;
+FLD=gcmfaces(nf,tp);
+
+for i=1:nf; FLD.f[i]=fill(fillval,s[i].+2N); end;
+#code below yields strange, seemingly incorrect results:
+#for i=1:nf; FLD.f[i]=Array{eltype(fld.f[i])}(undef,s[i].+2N); end;
+
+#all versions below yield same @time and memory (despite diff in allocs)
+for i=1:nf;
+# FLD.f[i][N+1:end-N,N+1:end-N]=fld.f[i];
+ @views FLD.f[i][N+1:N+s[i][1],N+1:N+s[i][2]]=fld.f[i];
 end;
 
-FLDU=FLDUtmp;
-FLDV=FLDVtmp;
+#step 2
 
-#now add the one extra point we need for U and V
-(FLDUtmp,FLDVtmp)=exch_UV_cs(fldU,fldV);
+(ovfW,ovfE,ovfS,ovfN,evfW,evfE,evfS,evfN)=exch_cs_viewfunctions();
 
-#then add the remaining rows and columns
-#... got to this point on 2018/08/14
+for a=1:nf
+(jW, jE, jS, jN)=exch_cs_target(s[a],N)
+(aW,aE,aS,aN,iW,iE,iS,iN)=exch_cs_sources(a,s,N)
+if !iseven(a)
+ aW <= nf ? FLD.f[a][jW[1],jW[2]]=ovfW(fld.f[aW],iW[1],iW[2]) : nothing
+ aE <= nf ? FLD.f[a][jE[1],jE[2]]=ovfE(fld.f[aE],iE[1],iE[2]) : nothing
+ aS <= nf ? FLD.f[a][jS[1],jS[2]]=ovfS(fld.f[aS],iS[1],iS[2]) : nothing
+ aN <= nf ? FLD.f[a][jN[1],jN[2]]=ovfN(fld.f[aN],iN[1],iN[2]) : nothing
+else
+ aW <= nf ? FLD.f[a][jW[1],jW[2]]=evfW(fld.f[aW],iW[1],iW[2]) : nothing
+ aE <= nf ? FLD.f[a][jE[1],jE[2]]=evfE(fld.f[aE],iE[1],iE[2]) : nothing
+ aS <= nf ? FLD.f[a][jS[1],jS[2]]=evfS(fld.f[aS],iS[1],iS[2]) : nothing
+ aN <= nf ? FLD.f[a][jN[1],jN[2]]=evfN(fld.f[aN],iN[1],iN[2]) : nothing
+end
+end
 
-#U face 1
-    tmp1=permutedims(FLDVtmp.f[5][:,end-N:end-1,:],[2 1 3]);
-    FLDU.f[1][1:N,N+1:end-N,:]=reverse(tmp1,dims=2);
-    tmp1=FLDUtmp.f[2][1:N,:,:];
-    FLDU.f[1][end-N+1:end,N+1:end-N,:]=tmp1;
-#
-    tmp1=FLDUtmp.f[6][:,end-N+1:end,:];
-    FLDU.f[1][N+1:end-N+1,1:N,:]=tmp1;
-    tmp1=permutedims(-FLDVtmp.f[3][1:N,:,:],[2 1 3]);
-    FLDU.f[1][N+1:end-N+1,end-N+1:end,:]=reverse(tmp1,dims=1);
-
-#V face 1
-    tmp1=permutedims(-FLDUtmp.f[5][:,end-N+1:end,:],[2 1 3]);
-    FLDV.f[1][1:N,N+1:end-N+1,:]=reverse(tmp1,dims=2);
-    tmp1=FLDVtmp.f[2][1:N,:,:];
-    FLDV.f[1][end-N+1:end,N+1:end-N+1,:]=tmp1;
-#
-    tmp1=FLDVtmp.f[6][:,end-N:end-1,:];
-    FLDV.f[1][N+1:end-N,1:N,:]=tmp1;
-    tmp1=permutedims(FLDUtmp.f[3][1:N,:,:],[2 1 3]);
-    FLDV.f[1][N+1:end-N,end-N+1:end,:]=reverse(tmp1,dims=1);
-
-#U face 2
-    tmp1=FLDUtmp.f[1][end-N:end-1,:,:];
-    FLDU.f[2][1:N,N+1:end-N,:]=tmp1;
-    tmp1=permutedims(FLDVtmp.f[4][:,1:N,:],[2 1 3]);
-    FLDU.f[2][end-N+1:end,N+1:end-N,:]=reverse(tmp1,dims=2);
-#
-    tmp1=permutedims(-FLDVtmp.f[6][end-N+1:end,:,:],[2 1 3]);
-    FLDU.f[2][N+1:end-N+1,1:N,:]=reverse(tmp1,dims=1);
-    tmp1=FLDUtmp.f[3][:,1:N,:];
-    FLDU.f[2][N+1:end-N+1,end-N+1:end,:]=tmp1;
-
-#V face 2
-    tmp1=FLDVtmp.f[1][end-N+1:end,:,:];
-    FLDV.f[2][1:N,N+1:end-N+1,:]=tmp1;
-    tmp1=permutedims(-FLDUtmp.f[4][:,1:N,:],[2 1 3]);
-    FLDV.f[2][end-N+1:end,N+1:end-N+1,:]=reverse(tmp1,dims=2);
-#
-    tmp1=permutedims(FLDUtmp.f[6][end-N:end-1,:,:],[2 1 3]);
-    FLDV.f[2][N+1:end-N,1:N,:]=reverse(tmp1,dims=1);
-    tmp1=FLDVtmp.f[3][:,1:N,:];
-    FLDV.f[2][N+1:end-N,end-N+1:end,:]=tmp1;
-
-#U face 3
-    tmp1=permutedims(FLDVtmp.f[1][:,end-N:end-1,:],[2 1 3]);
-    FLDU.f[3][1:N,N+1:end-N,:]=reverse(tmp1,dims=2);
-    tmp1=FLDUtmp.f[4][1:N,:,:];
-    FLDU.f[3][end-N+1:end,N+1:end-N,:]=tmp1;
-#
-    tmp1=FLDUtmp.f[2][:,end-N+1:end,:];
-    FLDU.f[3][N+1:end-N+1,1:N,:]=tmp1;
-    tmp1=permutedims(-FLDVtmp.f[5][1:N,:,:],[2 1 3]);
-    FLDU.f[3][N+1:end-N+1,end-N+1:end,:]=reverse(tmp1,dims=1);
-
-#V face 3
-    tmp1=permutedims(-FLDUtmp.f[1][:,end-N+1:end,:],[2 1 3]);
-    FLDV.f[3][1:N,N+1:end-N+1,:]=reverse(tmp1,dims=2);
-    tmp1=FLDVtmp.f[4][1:N,:,:];
-    FLDV.f[3][end-N+1:end,N+1:end-N+1,:]=tmp1;
-#
-    tmp1=FLDVtmp.f[2][:,end-N:end-1,:];
-    FLDV.f[3][N+1:end-N,1:N,:]=tmp1;
-    tmp1=permutedims(FLDUtmp.f[5][1:N,:,:],[2 1 3]);
-    FLDV.f[3][N+1:end-N,end-N+1:end,:]=reverse(tmp1,dims=1);
-
-#U face 4
-    tmp1=FLDUtmp.f[3][end-N:end-1,:,:];
-    FLDU.f[4][1:N,N+1:end-N,:]=tmp1;
-    tmp1=permutedims(FLDVtmp.f[6][:,1:N,:],[2 1 3]);
-    FLDU.f[4][end-N+1:end,N+1:end-N,:]=reverse(tmp1,dims=2);
-#
-    tmp1=permutedims(-FLDVtmp.f[2][end-N+1:end,:,:],[2 1 3]);
-    FLDU.f[4][N+1:end-N+1,1:N,:]=reverse(tmp1,dims=1);
-    tmp1=FLDUtmp.f[5][:,1:N,:];
-    FLDU.f[4][N+1:end-N+1,end-N+1:end,:]=tmp1;
-
-#V face 4
-    tmp1=FLDVtmp.f[3][end-N+1:end,:,:];
-    FLDV.f[4][1:N,N+1:end-N+1,:]=tmp1;
-    tmp1=permutedims(-FLDUtmp.f[6][:,1:N,:],[2 1 3]);
-    FLDV.f[4][end-N+1:end,N+1:end-N+1,:]=reverse(tmp1,dims=2);
-#
-    tmp1=permutedims(FLDUtmp.f[2][end-N:end-1,:,:],[2 1 3]);
-    FLDV.f[4][N+1:end-N,1:N,:]=reverse(tmp1,dims=1);
-    tmp1=FLDVtmp.f[5][:,1:N,:];
-    FLDV.f[4][N+1:end-N,end-N+1:end,:]=tmp1;
-
-#U face 5
-    tmp1=permutedims(FLDVtmp.f[3][:,end-N:end-1,:],[2 1 3]);
-    FLDU.f[5][1:N,N+1:end-N,:]=reverse(tmp1,dims=2);
-    tmp1=FLDUtmp.f[6][1:N,:,:];
-    FLDU.f[5][end-N+1:end,N+1:end-N,:]=tmp1;
-#
-    tmp1=FLDUtmp.f[4][:,end-N+1:end,:];
-    FLDU.f[5][N+1:end-N+1,1:N,:]=tmp1;
-    tmp1=permutedims(-FLDVtmp.f[1][1:N,:,:],[2 1 3]);
-    FLDU.f[5][N+1:end-N+1,end-N+1:end,:]=reverse(tmp1,dims=1);
-
-#V face 5
-    tmp1=permutedims(-FLDUtmp.f[3][:,end-N+1:end,:],[2 1 3]);
-    FLDV.f[5][1:N,N+1:end-N+1,:]=reverse(tmp1,dims=2);
-    tmp1=FLDVtmp.f[6][1:N,:,:];
-    FLDV.f[5][end-N+1:end,N+1:end-N+1,:]=tmp1;
-#
-    tmp1=FLDVtmp.f[4][:,end-N:end-1,:];
-    FLDV.f[5][N+1:end-N,1:N,:]=tmp1;
-    tmp1=permutedims(FLDUtmp.f[1][1:N,:,:],[2 1 3]);
-    FLDV.f[5][N+1:end-N,end-N+1:end,:]=reverse(tmp1,dims=1);
-
-#U face 6
-    tmp1=FLDUtmp.f[5][end-N:end-1,:,:];
-    FLDU.f[6][1:N,N+1:end-N,:]=tmp1;
-    tmp1=permutedims(FLDVtmp.f[2][:,1:N,:],[2 1 3]);
-    FLDU.f[6][end-N+1:end,N+1:end-N,:]=reverse(tmp1,dims=2);
-#
-    tmp1=permutedims(-FLDVtmp.f[4][end-N+1:end,:,:],[2 1 3]);
-    FLDU.f[6][N+1:end-N+1,1:N,:]=reverse(tmp1,dims=1);
-    tmp1=FLDUtmp.f[1][:,1:N,:];
-    FLDU.f[6][N+1:end-N+1,end-N+1:end,:]=tmp1;
-
-#V face 6
-    tmp1=FLDVtmp.f[5][end-N+1:end,:,:];
-    FLDV.f[6][1:N,N+1:end-N+1,:]=tmp1;
-    tmp1=permutedims(-FLDUtmp.f[2][:,1:N,:],[2 1 3]);
-    FLDV.f[6][end-N+1:end,N+1:end-N+1,:]=reverse(tmp1,dims=2);
-#
-    tmp1=permutedims(FLDUtmp.f[4][end-N:end-1,:,:],[2 1 3]);
-    FLDV.f[6][N+1:end-N,1:N,:]=reverse(tmp1,dims=1);
-    tmp1=FLDVtmp.f[1][:,1:N,:];
-    FLDV.f[6][N+1:end-N,end-N+1:end,:]=tmp1;
-
-    return FLDU,FLDV
+return FLD
 
 end
+
+##
+
+function exch_UV_N_cs(fldU::gcmfaces,fldV::gcmfaces,N::Integer)
+
+fillval=0.0
+
+#step 1
+
+s=size.(fldU.f);
+nf=fldU.nFaces;
+nf==5 ? s=vcat(s,s[3]) : nothing
+tp=fldU.grTopo;
+FLDU=gcmfaces(nf,tp);
+FLDV=gcmfaces(nf,tp);
+
+for i=1:nf;
+ FLDU.f[i]=fill(fillval,s[i].+2N);
+ FLDV.f[i]=fill(fillval,s[i].+2N);
+ @views FLDU.f[i][N+1:N+s[i][1],N+1:N+s[i][2]]=fldU.f[i];
+ @views FLDV.f[i][N+1:N+s[i][1],N+1:N+s[i][2]]=fldV.f[i];
+end;
+
+#step 2
+
+(ovfW,ovfE,ovfS,ovfN,evfW,evfE,evfS,evfN)=exch_cs_viewfunctions();
+
+for a=1:nf
+(jW, jE, jS, jN)=exch_cs_target(s[a],N)
+(aW,aE,aS,aN,iW,iE,iS,iN)=exch_cs_sources(a,s,N)
+if !iseven(a)
+ aW <= nf ? FLDU.f[a][jW[1],jW[2]]=ovfW(fldV.f[aW],iW[1],iW[2]) : nothing
+ aE <= nf ? FLDU.f[a][jE[1],jE[2]]=ovfE(fldU.f[aE],iE[1],iE[2]) : nothing
+ aS <= nf ? FLDU.f[a][jS[1],jS[2]]=ovfS(fldU.f[aS],iS[1],iS[2]) : nothing
+ aN <= nf ? FLDU.f[a][jN[1].+1,jN[2]]=-ovfN(fldV.f[aN],iN[1],iN[2]) : nothing
+ aW <= nf ? FLDV.f[a][jW[1],jW[2].+1]=-ovfW(fldU.f[aW],iW[1],iW[2]) : nothing
+ aE <= nf ? FLDV.f[a][jE[1],jE[2]]=ovfE(fldV.f[aE],iE[1],iE[2]) : nothing
+ aS <= nf ? FLDV.f[a][jS[1],jS[2]]=ovfS(fldV.f[aS],iS[1],iS[2]) : nothing
+ aN <= nf ? FLDV.f[a][jN[1],jN[2]]=ovfN(fldU.f[aN],iN[1],iN[2]) : nothing
+else
+ aW <= nf ? FLDU.f[a][jW[1],jW[2]]=evfW(fldU.f[aW],iW[1],iW[2]) : nothing
+ aE <= nf ? FLDU.f[a][jE[1],jE[2]]=evfE(fldV.f[aE],iE[1],iE[2]) : nothing
+ aS <= nf ? FLDU.f[a][jS[1].+1,jS[2]]=-evfS(fldV.f[aS],iS[1],iS[2]) : nothing
+ aN <= nf ? FLDU.f[a][jN[1],jN[2]]=evfN(fldU.f[aN],iN[1],iN[2]) : nothing
+ aW <= nf ? FLDV.f[a][jW[1],jW[2]]=evfW(fldV.f[aW],iW[1],iW[2]) : nothing
+ aE <= nf ? FLDV.f[a][jE[1],jE[2].+1]=-evfE(fldU.f[aE],iE[1],iE[2]) : nothing
+ aS <= nf ? FLDV.f[a][jS[1],jS[2]]=evfS(fldU.f[aS],iS[1],iS[2]) : nothing
+ aN <= nf ? FLDV.f[a][jN[1],jN[2]]=evfN(fldV.f[aN],iN[1],iN[2]) : nothing
+end
+end
+
+return FLDU,FLDV
+
+end
+
+##
+
+function exch_UV_cs(fldU::gcmfaces,fldV::gcmfaces)
+
+fillval=0.0
+
+#step 1
+
+s=size.(fldU.f);
+nf=fldU.nFaces;
+nf==5 ? s=vcat(s,s[3]) : nothing
+tp=fldU.grTopo;
+FLDU=gcmfaces(nf,tp);
+FLDV=gcmfaces(nf,tp);
+
+for i=1:nf
+  FLDU.f[i]=fill(fillval,s[i][1]+1,s[i][2]);
+  FLDV.f[i]=fill(fillval,s[i][1],s[i][2]+1);
+  @views FLDU.f[i][1:s[i][1],1:s[i][2]]=fldU.f[i];
+  @views FLDV.f[i][1:s[i][1],1:s[i][2]]=fldV.f[i];
+end
+
+ #step 2
+
+(ovfW,ovfE,ovfS,ovfN,evfW,evfE,evfS,evfN)=exch_cs_viewfunctions();
+
+for a=1:nf
+(jW, jE, jS, jN)=exch_cs_target(s[a],1)
+(aW,aE,aS,aN,iW,iE,iS,iN)=exch_cs_sources(a,s,1)
+if !iseven(a)
+ aE <= nf ? FLDU.f[a][jE[1].-1,jE[2].-1]=ovfE(fldU.f[aE],iE[1],iE[2]) : nothing
+ aN <= nf ? FLDV.f[a][jN[1].-1,jN[2].-1]=ovfN(fldU.f[aN],iN[1],iN[2]) : nothing
+else
+ aE <= nf ? FLDU.f[a][jE[1].-1,jE[2].-1]=evfE(fldV.f[aE],iE[1],iE[2]) : nothing
+ aN <= nf ? FLDV.f[a][jN[1].-1,jN[2].-1]=evfN(fldV.f[aN],iN[1],iN[2]) : nothing
+end
+end
+
+return FLDU,FLDV
+
+end
+
+## Convenience functions used in the cs & llc case
+
+function exch_cs_target(sa::Tuple{Int64,Int64},N::Integer)
+
+    #target array indices
+    jW=(1:N,N+1:N+sa[2]);
+    jE=(N+1+sa[1]:2N+sa[1],N+1:N+sa[2]);
+    jS=(N+1:N+sa[1],1:N);
+    jN=(N+1:N+sa[1],N+1+sa[2]:2N+sa[2]);
+
+    return jW, jE, jS, jN
+
+end
+
+function exch_cs_sources(a::Integer,s::Array{Tuple{Int64,Int64},1},N::Integer)
+
+#source array IDs
+aW=0; aE=0; aS=0; aN=0;
+if a==1;     aW=5; aE=2; aS=6; aN=3;
+elseif a==2; aW=1; aE=4; aS=6; aN=3;
+elseif a==3; aW=1; aE=4; aS=2; aN=5;
+elseif a==4; aW=3; aE=6; aS=2; aN=5;
+elseif a==5; aW=3; aE=6; aS=4; aN=1;
+elseif a==6; aW=5; aE=2; aS=4; aN=1;
+else; error("Array index is out of bounds.");
+end;
+
+if !iseven(a)
+    #source array indices
+    iW=(1:s[aW][1],s[aW][2]-N+1:s[aW][2]);
+    iE=(1:N,1:s[aE][2]);
+    iS=(1:s[aS][1],s[aS][2]-N+1:s[aS][2]);
+    iN=(1:N,1:s[aN][2]);
+else
+    #source array indices
+    iW=(s[aW][1]-N+1:s[aW][1],1:s[aW][2]);
+    iE=(1:s[aE][1],1:N);
+    iS=(s[aS][1]-N+1:s[aS][1],1:s[aS][2]);
+    iN=(1:s[aN][1],1:N);
+end
+
+return aW,aE,aS,aN,iW,iE,iS,iN
+end
+
+function exch_cs_viewfunctions()
+#view functions for odd numbered arrays
+ovfW(x,i,j)=PermutedDimsArray(view(x,reverse(i),j),(2,1))
+ovfE(x,i,j)=view(x,i,j)
+ovfS(x,i,j)=view(x,i,j)
+ovfN(x,i,j)=PermutedDimsArray(view(x,i,reverse(j)),(2,1))
+#view functions for even numbered arrays
+evfW(x,i,j)=view(x,i,j)
+evfE(x,i,j)=PermutedDimsArray(view(x,reverse(i),j),(2,1))
+evfS(x,i,j)=PermutedDimsArray(view(x,i,reverse(j)),(2,1))
+evfN(x,i,j)=view(x,i,j)
+#
+return ovfW,ovfE,ovfS,ovfN,evfW,evfE,evfS,evfN
+end
+
+##

--- a/src/gcmfaces_type.jl
+++ b/src/gcmfaces_type.jl
@@ -146,13 +146,18 @@ import Base: isnan, isinf, isfinite
 import Base: maximum, minimum, sum, fill
 
 function +(a::gcmfaces)
-  c=gcmfaces(a.nFaces,a.grTopo,a.f)
+  c=gcmfaces(a.nFaces,a.grTopo)
+  for iFace=1:a.nFaces
+    c.f[iFace]=+a.f[iFace];
+  end
   return c
 end
 
 function +(a::gcmfaces,b::gcmfaces)
-  cf=a.f+b.f
-  c=gcmfaces(a.nFaces,a.grTopo,cf)
+  c=gcmfaces(a.nFaces,a.grTopo)
+  for iFace=1:a.nFaces
+    c.f[iFace]=a.f[iFace]+b.f[iFace];
+  end
   return c
   #the following modifies a:
   #  c=a
@@ -163,15 +168,10 @@ function +(a::gcmfaces,b::gcmfaces)
 end
 
 function +(a::Number,b::gcmfaces)
-  nFaces=b.nFaces;
-  grTopo=b.grTopo;
-  v1=Array{Any}(undef,nFaces);
-  for iFace=1:nFaces
-    tmp1=b.f[iFace];
-    tmp2=a*ones(Float64, size(tmp1));
-    v1[iFace]=tmp1+tmp2;
+  c=gcmfaces(b.nFaces,b.grTopo)
+  for iFace=1:b.nFaces
+    c.f[iFace]=a.+b.f[iFace];
   end
-  c=gcmfaces(nFaces,grTopo,v1);
   return c
   #the following is deprecated synthax as of v0.7:
   #  c=gcmfaces(b.nFaces,b.grTopo)
@@ -184,92 +184,87 @@ function +(a::gcmfaces,b::Number)
 end
 
 function -(a::gcmfaces)
-  c=gcmfaces(a.nFaces,a.grTopo,-a.f)
+  c=gcmfaces(a.nFaces,a.grTopo)
+  for iFace=1:a.nFaces
+    c.f[iFace]=-a.f[iFace];
+  end
   return c
 end
 
 function -(a::gcmfaces,b::gcmfaces)
-  cf=a.f .- b.f
-  c=gcmfaces(a.nFaces,a.grTopo,cf)
+  c=gcmfaces(a.nFaces,a.grTopo)
+  for iFace=1:a.nFaces
+    c.f[iFace]=a.f[iFace]-b.f[iFace];
+  end
   return c
 end
 
 function -(a::Number,b::gcmfaces)
-  nFaces=b.nFaces;
-  grTopo=b.grTopo;
-  v1=Array{Any}(undef,nFaces);
-  for iFace=1:nFaces
-    tmpb=b.f[iFace];
-    tmpa=a*ones(Float64,size(tmpb));
-    v1[iFace]=tmpa-tmpb;
+  c=gcmfaces(b.nFaces,b.grTopo)
+  for iFace=1:b.nFaces
+    c.f[iFace]=a.-b.f[iFace];
   end
-  c=gcmfaces(b.nFaces,b.grTopo,v1);
   return c
 end
 
 function -(a::gcmfaces,b::Number)
-  nFaces=a.nFaces;
-  grTopo=a.grTopo;
-  v1=Array{Any}(undef,nFaces);
-  for iFace=1:nFaces
-    tmpa=a.f[iFace];
-    tmpb=b*ones(Float64,size(tmpa));
-    v1[iFace]=tmpa-tmpb;
+  c=gcmfaces(a.nFaces,a.grTopo)
+  for iFace=1:a.nFaces
+    c.f[iFace]=a.f[iFace].-b;
   end
-  c=gcmfaces(a.nFaces,a.grTopo,v1);
   return c
 end
 
 function *(a::gcmfaces,b::gcmfaces)
   nFaces=a.nFaces;
   grTopo=a.grTopo;
-  v1=Array{Any}(undef,nFaces);
+  c=gcmfaces(nFaces,grTopo);
   for iFace=1:nFaces
-    v1[iFace]=a.f[iFace] .* b.f[iFace];
+    c.f[iFace]=a.f[iFace].*b.f[iFace];
   end
-  c=gcmfaces(nFaces,grTopo,v1);
   return c
 end
 
 function *(a::Number,b::gcmfaces)
-  v1=a .* b.f;
-  c=gcmfaces(b.nFaces,b.grTopo,v1);
+  c=gcmfaces(b.nFaces,b.grTopo);
+  for iFace=1:b.nFaces
+    c.f[iFace]=a*b.f[iFace];
+  end
   return c
 end
 
 function *(a::gcmfaces,b::Number)
-  v1=b .* a.f;
-  c=gcmfaces(a.nFaces,a.grTopo,v1);
+  c=b*a
   return c
 end
 
 function /(a::gcmfaces,b::gcmfaces)
   nFaces=a.nFaces;
   grTopo=a.grTopo;
-  v1=Array{Any}(undef,nFaces);
+  c=gcmfaces(nFaces,grTopo);
   for iFace=1:nFaces
-    v1[iFace]=a.f[iFace] ./ b.f[iFace];
+    c.f[iFace]=a.f[iFace]./b.f[iFace];
   end
-  c=gcmfaces(nFaces,grTopo,v1);
   return c
 end
 
 function /(a::Number,b::gcmfaces)
   nFaces=b.nFaces;
   grTopo=b.grTopo;
-  v1=Array{Any}(undef,nFaces);
+  c=gcmfaces(nFaces,grTopo);
   for iFace=1:nFaces
-    v1[iFace]=a ./ b.f[iFace];
+    c.f[iFace]=a./b.f[iFace];
   end
-  c=gcmfaces(nFaces,grTopo,v1);
   return c
 end
 
 function /(a::gcmfaces,b::Number)
   nFaces=a.nFaces;
   grTopo=a.grTopo;
-  v1=a.f ./ b;
-  c=gcmfaces(nFaces,grTopo,v1);
+  c=gcmfaces(nFaces,grTopo);
+  for iFace=1:nFaces
+    c.f[iFace]=a.f[iFace]./b;
+  end
   return c
 end
 
@@ -278,41 +273,35 @@ end
 function isnan(a::gcmfaces)
     nFaces=a.nFaces;
     grTopo=a.grTopo;
-    v1=Array{Any}(undef,nFaces);
-    for iFace=1:nFaces
-      tmp1=a.f[iFace];
-      v1[iFace]=isnan.(tmp1);
+    c=gcmfaces(a.nFaces,a.grTopo);
+    for iFace=1:a.nFaces
+      c.f[iFace]=isnan.(a.f[iFace]);
     end
-    c=gcmfaces(nFaces,grTopo,v1);
     return c
 end
 
 function isinf(a::gcmfaces)
     nFaces=a.nFaces;
     grTopo=a.grTopo;
-    v1=Array{Any}(undef,nFaces);
-    for iFace=1:nFaces
-      tmp1=a.f[iFace];
-      v1[iFace]=isinf.(tmp1);
+    c=gcmfaces(a.nFaces,a.grTopo);
+    for iFace=1:a.nFaces
+      c.f[iFace]=isinf.(a.f[iFace]);
     end
-    c=gcmfaces(nFaces,grTopo,v1);
     return c
 end
 
 function isfinite(a::gcmfaces)
     nFaces=a.nFaces;
     grTopo=a.grTopo;
-    v1=Array{Any}(undef,nFaces);
-    for iFace=1:nFaces
-      tmp1=a.f[iFace];
-      v1[iFace]=isfinite.(tmp1);
+    c=gcmfaces(a.nFaces,a.grTopo);
+    for iFace=1:a.nFaces
+      c.f[iFace]=isfinite.(a.f[iFace]);
     end
-    c=gcmfaces(nFaces,grTopo,v1);
     return c
 end
 
 function sum(a::gcmfaces)
-    c=0.;
+    c=0.0;
     for iFace=1:a.nFaces
       tmp1=a.f[iFace];
       c=c+sum(tmp1);
@@ -339,13 +328,9 @@ function minimum(a::gcmfaces)
 end
 
 function fill(val::Any,a::gcmfaces)
-    nFaces=a.nFaces;
-    grTopo=a.grTopo;
-    v1=Array{Any}(undef,nFaces);
-    for iFace=1:nFaces
-      tmp1=a.f[iFace];
-      v1[iFace]=fill(val,size(tmp1));
+    c=gcmfaces(a.nFaces,a.grTopo);
+    for iFace=1:a.nFaces
+      c.f[iFace]=fill(val,fsize(a,iFace));
     end
-    c=gcmfaces(nFaces,grTopo,v1);
     return c
 end


### PR DESCRIPTION
- gcmfaces_exch.jl: rewrite exchange functions in a much more performant
  fashion based on views and subfunctions; exch_cs_target, exch_cs_sources,
  and exch_cs_viewfunctions do most of the work for both cs and llc cases.
- gcmfaces_cal.jl: revisit methods to improve performance of e.g. smooth
  mask: revised behavior and handling of  input arguments
  gradient: now 3 methods; dispatch -> different treatments of 1/DXC, 1/DYC
  mask: revised behavior and handling of  input arguments
  convergence: remove mask calls, use view, avoid end
  smooth: revised handling of masks, 1/DXC etc factors, precomputed
    KuxFac/KvyFac/dtFac before main nbt loop, and add nFaces-loops
    within main nbt loop to improve performance (time and memory)
- gcmfaces_type.jl: streamline arithmetic operation methods
- MeshArrays.jl: add convergence to export list