### PR TITLE
Enable `interpolation_setup` to download precomputed weights for LLC90 or LLC270

### DIFF
--- a/ext/MeshArraysDataDepsExt.jl
+++ b/ext/MeshArraysDataDepsExt.jl
@@ -26,6 +26,10 @@ module MeshArraysDataDepsExt
          "Interpolation coefficients example, from LLC90 grid to half degree grid, created with MeshArrays.jl",
          ["https://zenodo.org/record/5784905/files/interp_coeffs_halfdeg.jld2"],
          "a0e2806ad2a88c0acb5d3baef942fcbcf69fe27310487894cd38f6c782f55e99"))
+      register(DataDep("interp_quarterdeg",
+         "Interpolation coefficients from LLC270 grid to quarter degree grid, created with MeshArrays.jl",
+         ["https://zenodo.org/records/19211947/files/interp_coeffs_quarterdeg.jld2"],
+         "b4c49ebf553af390cebc040f210fee1124e89a1eb9ab0cad137dd7b4e457156c"))
       end
 
  
@@ -39,6 +43,7 @@ module MeshArraysDataDepsExt
    "countries_geojson1"
    "basemap_jpg1"
    "interp_halfdeg"
+   "interp_quarterdeg"
    "oceans_geojson1"
    ```    
    """
@@ -52,6 +57,8 @@ module MeshArraysDataDepsExt
             datadep"basemap_jpg1"
          elseif nam=="interp_halfdeg"
             datadep"interp_halfdeg"
+         elseif nam=="interp_quarterdeg"
+            datadep"interp_quarterdeg"
          elseif nam=="oceans_geojson1"
             datadep"oceans_geojson1"
          else

--- a/src/Datasets.jl
+++ b/src/Datasets.jl
@@ -66,6 +66,8 @@ function mydatafile(nam="countries_shp1")
         "Blue_Marble_Next_Generation_%2B_topography_%2B_bathymetry.jpg"
     elseif nam=="interp_halfdeg"
         "interp_coeffs_halfdeg.jld2"
+    elseif nam=="interp_quarterdeg"
+        "interp_coeffs_quarterdeg.jld2"
     elseif nam=="oceans_geojson1"
         "ocean_basins_res1000_20251109_GF.json"
     else

--- a/src/Interpolation.jl
+++ b/src/Interpolation.jl
@@ -236,17 +236,26 @@ function interpolation_setup(fil::String)
 end
 
 """
-        interpolation_setup(Γ::gcmgrid)
+        interpolation_setup(γ::gcmgrid)
 
-Read 
+Download/read precomputed interpolation coefficients for gcmgrid `γ` if they exist,
+        currently for LLC90 and LLC270, otherwise compute interpolation coefficients 
+        defaulting to 2° grid.
 """
 function interpolation_setup(γ::gcmgrid)
-        fil=if γ.class*string(γ.ioSize[1])=="LatLonCap90"
-                MeshArrays.Dataset("interp_halfdeg",do_read=false)
+        if γ.class*string(γ.ioSize[1])=="LatLonCap90"
+                interpolation_setup(
+                        MeshArrays.Dataset("interp_halfdeg",do_read=false)
+                )
         elseif γ.class*string(γ.ioSize[1])=="LatLonCap270"
-                MeshArrays.Dataset("interp_quarterdeg",do_read=false)
+                interpolation_setup(
+                        MeshArrays.Dataset("interp_quarterdeg",do_read=false)
+                )
+        else
+                # Default to 2 degree interpolation weights for other grids
+                Γ=GridLoad(γ; option="full")
+                interpolation_setup(; Γ)
         end     
-        interpolation_setup(fil)
 end
 
 """

--- a/src/Interpolation.jl
+++ b/src/Interpolation.jl
@@ -236,6 +236,20 @@ function interpolation_setup(fil::String)
 end
 
 """
+        interpolation_setup(Γ::gcmgrid)
+
+Read 
+"""
+function interpolation_setup(γ::gcmgrid)
+        fil=if γ.class*string(γ.ioSize[1])=="LatLonCap90"
+                MeshArrays.Dataset("interp_halfdeg",do_read=false)
+        elseif γ.class*string(γ.ioSize[1])=="LatLonCap270"
+                MeshArrays.Dataset("interp_quarterdeg",do_read=false)
+        end     
+        interpolation_setup(fil)
+end
+
+"""
     interpolation_setup(;Γ,lon,lat,filename)
     
 Download or recompute interpolation coefficients.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -293,14 +293,31 @@ end
     GridLoad(GridSpec("ones"))
 end
 
+@testset "Interpolation" begin
+    λ=interpolation_setup()
+    # Test LLC270 interpolation coefficients
+    γ=GridSpec(ID=:LLC270)
+    λ=interpolation_setup(γ)
+    @test isa(λ,NamedTuple)
+    @test all(isfinite.(λ.f))
+    # Test outside LLC90/LLC270
+    γ=GridSpec(ID=:CS32)
+    λ=interpolation_setup(γ)
+    @test isa(λ,NamedTuple)
+    @test all(isfinite.(λ.f))
+
+    Γ=GridLoad(γ;option="light")
+    λ=interpolation_setup(Γ=Γ,
+        lon=[i for i=-170.:20.0:170., j=-80.:20.0:80.], 
+        lat=[j for i=-170.:20.0:170., j=-80.:20.0:80.])
+    @test isa(λ,NamedTuple)
+    @test all(isfinite.(λ.f))
+end
+
 @testset "Plotting:" begin
     γ=GridSpec(ID=:LLC90)
     Γ=GridLoad(γ;option="light")
     D=Γ.Depth
-    λ=interpolation_setup(Γ=Γ,
-        lon=[i for i=-170.:20.0:170., j=-80.:20.0:80.], 
-        lat=[j for i=-170.:20.0:170., j=-80.:20.0:80.])
-    λ=interpolation_setup(γ)
     λ=interpolation_setup()
 
     lines(pol_json); lines!(pol_json)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -295,6 +295,13 @@ end
 
 @testset "Interpolation" begin
     λ=interpolation_setup()
+    @test isa(λ,NamedTuple)
+    @test all(isfinite.(λ.f))
+    # Test LLC90 interpolation coefficients
+    γ=GridSpec(ID=:LLC90)
+    λ=interpolation_setup(γ)
+    @test isa(λ,NamedTuple)
+    @test all(isfinite.(λ.f))
     # Test LLC270 interpolation coefficients
     γ=GridSpec(ID=:LLC270)
     λ=interpolation_setup(γ)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -300,6 +300,7 @@ end
     λ=interpolation_setup(Γ=Γ,
         lon=[i for i=-170.:20.0:170., j=-80.:20.0:80.], 
         lat=[j for i=-170.:20.0:170., j=-80.:20.0:80.])
+    λ=interpolation_setup(γ)
     λ=interpolation_setup()
 
     lines(pol_json); lines!(pol_json)


### PR DESCRIPTION
I added a method to `interpolation_setup`, which allows down/loading of precomputed interpolation weights based on the `GridSpec` (i.e. either 0.5° for ID=:LLC90 or 0.25° for ID=:LLC270). 
```julia
γ=GridSpec(ID=:LLC270)
 gcmgrid 
  class        = LatLonCap
  path         = /Users/jml1/.julia/artifacts/1bc43784dfbcb787cc4e8018ab61d5c3cdcd5ea3/GRID_LLC270-1.0.0/
  fSize        = [(270, 810), (270, 810), (270, 270), (810, 270), (810, 270)]
  ioSize       = [270 3510]
  ioPrec       = Float32

λ=interpolation_setup(γ)
(lat = [-89.875 -89.625 … 89.625 89.875; -89.875 -89.625 … 89.625 89.875; … ; -89.875 -89.625 … 89.625 89.875; -89.875 -89.625 … 89.625 89.875], f = [4 4 4 4; 4 4 4 4; … ; 3 3 3 3; 3 3 3 3], w = [0.038147161848044925 0.32800134934748143 0.5678137074351091 0.06603778136936453; 0.03588516073953725 0.319724971993188 0.5793635031754644 0.06502636409181044; … ; 0.30958104671667847 0.3210276065472765 0.1880481964656952 0.18134315027034986; 0.3070680754881118 0.31913638642184666 0.19049969226156438 0.1832958458284772], j = [40 40 41 41; 40 40 41 41; … ; 135 135 136 136; 135 135 136 136], lon = [-179.875 -179.875 … -179.875 -179.875; -179.625 -179.625 … -179.625 -179.625; … ; 179.625 179.625 … 179.625 179.625; 179.875 179.875 … 179.875 179.875], i = [808 809 809 808; 808 809 809 808; … ; 136 137 137 136; 136 137 137 136])
```

This could be expanded to other model grids (for example `ID=:CS32`), but currently supplying an unrecognized gcmgrid falls back on calculating interpolation weights on the default 2° grid.
```julia
γ=GridSpec(ID=:CS32)
 gcmgrid 
  class        = CubeSphere
  path         = /Users/jml1/.julia/artifacts/e425ca76b87758101e7f7543eee62d34f7b4553f/GRID_CS32-1.1/
  fSize        = [(32, 32), (32, 32), (32, 32), (32, 32), (32, 32), (32, 32)]
  ioSize       = [32 192]
  ioPrec       = Float32

λ=interpolation_setup(γ)
(lat = [-89.0 -87.0 … 87.0 89.0; -89.0 -87.0 … 87.0 89.0; … ; -89.0 -87.0 … 87.0 89.0; -89.0 -87.0 … 87.0 89.0], f = [6 6 6 6; 6 6 6 6; … ; 3 3 3 3; 3 3 3 3], w = [0.4266968067160594 0.41659067208909717 0.07741722267931467 0.07929529851552865; 0.4365801480888083 0.40628908780280665 0.07574189695964063 0.08138886714874438; … ; 0.08138952033431214 0.43657942774664493 0.40628852672078924 0.07574252519825363; 0.07929594418742816 0.4266961386495333 0.4165900571683199 0.07741785999471859], j = [16 16 17 17; 16 16 17 17; … ; 16 16 17 17; 16 16 17 17], lon = [-179.0 -179.0 … -179.0 -179.0; -177.0 -177.0 … -177.0 -177.0; … ; 177.0 177.0 … 177.0 177.0; 179.0 179.0 … 179.0 179.0], i = [16 17 17 16; 16 17 17 16; … ; 16 17 17 16; 16 17 17 16])
```

All other behavior is the same, including interpolation_setup with no arguments, and interpolation_setup with a path to saved JLD2 weight file.

