### PR TITLE
Fix broadcasting (`.=`) for `AbstractMeshArray`: correct `copyto!` dispatch and `ones`/`zeros`/`fill` allocation

### DIFF
--- a/src/types/gcmarray.jl
+++ b/src/types/gcmarray.jl
@@ -342,30 +342,25 @@ end
 
 Base.BroadcastStyle(::Type{<:AbstractMeshArray}) = Broadcast.ArrayStyle{AbstractMeshArray}()
 
-function Base.similar(bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{AbstractMeshArray}}, ::Type{ElType}) where ElType
+function Base.similar(bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{AbstractMeshArray}},
+                      ::Type{ElType}) where ElType
     A = find_gcmarray(bc)
     nFaces = length(A.fIndex)
-
     if ndims(A) == 1
-        # 1D case: lazy init — copyto! will allocate on first write
-        f = fill(InnerArray{ElType}(undef, 0,0), nFaces)
-        B = gcmarray{ElType, 1, InnerArray{ElType,2}}(
+        f = fill(InnerArray{ElType}(undef, 0, 0), nFaces)
+        return gcmarray{ElType, 1, InnerArray{ElType,2}}(
             A.grid, defaultmeta, f, A.fSize, A.fIndex, thisversion)
     elseif ndims(A) == 2
-        # 2D case: lazy init — copyto! will allocate on first write
         n3 = size(A, 2)
-        f = fill(InnerArray{ElType}(undef, 0,0), nFaces, n3)
-        B = gcmarray{ElType, 2, InnerArray{ElType,2}}(
+        f = fill(InnerArray{ElType}(undef, 0, 0), nFaces, n3)
+        return gcmarray{ElType, 2, InnerArray{ElType,2}}(
             A.grid, defaultmeta, f, A.fSize, A.fIndex, thisversion)
-    else  # ndims(A) == 3
-        # 3D case: lazy init — copyto! will allocate on first write
-        n3 = size(A, 2)
-        n4 = size(A, 3)
-        f = fill(InnerArray{ElType}(undef, 0,0), nFaces, n3, n4)
-        B = gcmarray{ElType, 3, InnerArray{ElType,2}}(
+    else
+        n3, n4 = size(A, 2), size(A, 3)
+        f = fill(InnerArray{ElType}(undef, 0, 0), nFaces, n3, n4)
+        return gcmarray{ElType, 3, InnerArray{ElType,2}}(
             A.grid, defaultmeta, f, A.fSize, A.fIndex, thisversion)
     end
-    return B
 end
 
 find_gcmarray(bc::Base.Broadcast.Broadcasted) = find_gcmarray(bc.args)
@@ -374,39 +369,27 @@ find_gcmarray(x) = x
 find_gcmarray(a::AbstractMeshArray, rest) = a
 find_gcmarray(::Any, rest) = find_gcmarray(rest)
 
-####
+# Recursively rewrite a Broadcasted tree for face I:
+# replace each AbstractMeshArray leaf with its per-face InnerArray;
+# scalars and plain Arrays pass through unchanged.
+function _bc_face(bc::Broadcast.Broadcasted, I)
+    new_args = map(a -> _bc_face(a, I), bc.args)
+    Broadcast.Broadcasted(bc.f, new_args)
+end
+_bc_face(a::AbstractMeshArray, I) = ndims(a.f) == 1 ? a.f[I[1]] : a.f[I]
+_bc_face(a, I) = a
 
 import Base: copyto!
 
-# Rewrite a Broadcasted tree: replace AbstractMeshArray args with their face-I inner arrays.
-# Scalars and plain arrays pass through unchanged.
-function _bc_face(bc::Broadcast.Broadcasted, I)
-    new_args = map(a -> _bc_face(a, I), bc.args)
-    Broadcast.Broadcasted(bc.f, new_args)  # axes=nothing → recomputed from face arrays
-end
-_bc_face(a::AbstractMeshArray, I) = ndims(a.f) == 1 ? a.f[I[1]] : a.f[I]
-_bc_face(a, I) = a  # scalar, plain array, etc.
-
-@inline function copyto!(dest::AbstractMeshArray, bc::Broadcast.Broadcasted{Nothing})
-    axes(dest) == axes(bc) || throwdm(axes(dest), axes(bc))
+@inline function Base.copyto!(dest::AbstractMeshArray,
+                               bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{AbstractMeshArray}})
     for I in CartesianIndices(dest.f)
-        face_args = map(a -> _bc_face(a, I), bc.args)
-        array_args = filter(a -> isa(a, AbstractArray), face_args)
-        if !isempty(array_args)
-            result_axes = Base.Broadcast.combine_axes(array_args...)
-            result_size = map(length, result_axes)
-            if size(dest.f[I]) != result_size
-                dest.f[I] = similar(dest.f[I], result_size)
-            end
+        face_bc = _bc_face(bc, I)
+        if size(dest.f[I]) == (0, 0)
+            dest.f[I] = Base.Broadcast.materialize(face_bc)
+        else
+            Base.Broadcast.materialize!(dest.f[I], face_bc)
         end
-        broadcast!(bc.f, dest.f[I], face_args...)
     end
     return dest
 end
-
-function gcmarray_getindex_evalf(bc,I)
-  @boundscheck checkbounds(bc, I)
-  args = Broadcast._getindex(bc.args, I)
-  return bc.f.(args...)
-end
-

--- a/src/types/main.jl
+++ b/src/types/main.jl
@@ -161,7 +161,7 @@ function sum(a::AbstractMeshArray)
 end
 
 function fill(val::Any,a::AbstractMeshArray)
-  c=similar(a)
+  c=similar(a, allocate=true)
   for I in eachindex(a.f)
     c.f[I] = fill(val,size(a.f[I]))
   end
@@ -236,13 +236,13 @@ function ones(a::gcmgrid,args...)
 end
 
 function zeros(a::AbstractMeshArray)
-  b=similar(a)
+  b=similar(a, allocate=true)
   [b.f[c].=0.0 for c in eachindex(b.f)]
   b
 end
 
 function ones(a::AbstractMeshArray)
-  b=similar(a)
+  b=similar(a, allocate=true)
   [b.f[c].=1.0 for c in eachindex(b.f)]
   b
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ include_maybe(name) = ("all" in _RUN || name in _RUN) && include("testsets/$name
 
 include_maybe("datasets")
 include_maybe("mesharray_basic")
+include_maybe("broadcast")
 include_maybe("vertical_dim")
 include_maybe("regional_integration")
 include_maybe("transport")

--- a/test/testsets/broadcast.jl
+++ b/test/testsets/broadcast.jl
@@ -1,0 +1,27 @@
+@testset "broadcast .= equivalence" begin
+    γ = GridSpec(ID=:LLC90)
+    Γ = GridLoad(γ, option="full")
+    u = MeshArray(γ, Float32, 10)
+    for I in eachindex(u.f)
+        u.f[I] = rand(Float32, size(u.f[I])...)
+    end
+
+    # Test 1: A .= B  (plain copy)
+    u2 = similar(u, allocate=true)
+    u2 .= u
+    @test all(I -> u2.f[I] == u.f[I], eachindex(u.f))
+
+    # Test 2: A .= scalar .* B
+    u3 = similar(u, allocate=true)
+    u3 .= 2.0f0 .* u
+    @test all(I -> u3.f[I] == 2.0f0 .* u.f[I], eachindex(u.f))
+
+    # Test 3: A .= B .* C (the Drifters.jl pattern, whole array)
+    u4 = similar(u, allocate=true)
+    ref = similar(u, allocate=true)
+    for I in eachindex(u.f)
+        ref.f[I] = u.f[I] .* 2.0f0
+    end
+    u4 .= u .* 2.0f0
+    @test all(I -> u4.f[I] == ref.f[I], eachindex(u.f))
+end


### PR DESCRIPTION
- **Fixes:** #xxx (broadcast `.=` fails with `DimensionMismatch` or `BoundsError`)
- add `test/testsets/broadcast.jl`
---

### Problem

Two related bugs caused `.=` to fail silently or with errors on `AbstractMeshArray`:

**Bug 1 — `copyto!` wrong dispatch (`gcmarray.jl`)**

The existing `copyto!` was defined as:
```julia
function copyto!(dest::AbstractMeshArray, bc::Broadcast.Broadcasted{Nothing})
```
Julia's `materialize!` preserves the broadcast style, so the `Broadcasted` arriving at `copyto!` always carries `ArrayStyle{AbstractMeshArray}` — never `Nothing`. This method was therefore **never dispatched**, causing fallback to Julia's generic broadcast machinery which iterates using `axes(dest)`. Since `size(A::AbstractMeshArray)` returns outer face-tile dimensions rather than element-wise dimensions, this produced `BoundsError` or `DimensionMismatch`.

**Bug 2 — `ones`/`zeros`/`fill` return unallocated arrays (`main.jl`)**

```julia
function ones(a::AbstractMeshArray)
    b = similar(a)              # lazy: all faces are (0,0) placeholders
    [b.f[c] .= 1.0 for c in eachindex(b.f)]  # silent no-op on (0,0) faces
    b                           # returns unallocated gcmarray
end
```
`similar(a)` without `allocate=true` creates lazy `(0,0)` placeholder faces. The subsequent `.=` fill was a silent no-op. Bug 1 had been masking this: the old broken `copyto!` path happened to not error on `(0,0)` faces. Bug 1's fix correctly surfaced it.

---

### Fix

**`src/types/gcmarray.jl`** — correct `copyto!` signature and implementation:
```julia
@inline function Base.copyto!(dest::AbstractMeshArray,
                               bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{AbstractMeshArray}})
    for I in CartesianIndices(dest.f)
        face_bc = _bc_face(bc, I)
        if size(dest.f[I]) == (0, 0)
            dest.f[I] = Base.Broadcast.materialize(face_bc)
        else
            Base.Broadcast.materialize!(dest.f[I], face_bc)
        end
    end
    return dest
end
```

**`src/types/main.jl`** — use `allocate=true` in `ones`, `zeros`, and `fill`:
```julia
function ones(a::AbstractMeshArray)
    b = similar(a, allocate=true)
    [b.f[c] .= 1.0 for c in eachindex(b.f)]
    b
end

function zeros(a::AbstractMeshArray)
    b = similar(a, allocate=true)
    [b.f[c] .= 0.0 for c in eachindex(b.f)]
    b
end

function fill(val::Any, a::AbstractMeshArray)
    c = similar(a, allocate=true)
    for I in eachindex(a.f)
        c.f[I] = fill(val, size(a.f[I]))
    end
    return c
end
```

---

### Effect

After this fix, `.=` and `=` are equivalent for `AbstractMeshArray`, as expected for a well-behaved `AbstractArray` subtype. For example, this pattern (from `Drifters.jl`) now works correctly:

```julia
for k = 1:nr
    u0[:,k] .= u0[:,k] .* D.iDXC   # ✅ now works
end
```

