### PR TITLE
Fix slice broadcast .= for AbstractMeshArray

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MeshArrays"
 uuid = "cb8c808f-1acf-59a3-9d2b-6e38d009f683"
-version = "0.5.10"
+version = "0.5.11"
 authors = ["gaelforget <gforget@mit.edu>"]
 
 [deps]

--- a/src/types/gcmarray.jl
+++ b/src/types/gcmarray.jl
@@ -208,33 +208,33 @@ end
 
 function Base.view(A::AbstractMeshArray{T, N}, I::Vararg{Union{Int,AbstractUnitRange,Colon}, N}) where {T,N}
     J = 1:length(A.fIndex)
-    !isa(I[1], Colon) ? J = J[I[1]] : nothing
+    if !isa(I[1], Colon)
+        idx = J[I[1]]
+        J = isa(idx, Int) ? (idx:idx) : idx
+    end
     nFaces = length(J)
-    
+
     tmpf = view(A.f, I...)
     n3 = Int(length(tmpf) / nFaces)
-    
-    fSize_sub = A.fSize[J]
+
+    fSize_sub  = A.fSize[J]
     fIndex_sub = A.fIndex[J]
-    
+
     if n3 == 1
-        # 1D result
         f_new = OuterArray{InnerArray{T,2},1}(undef, nFaces)
         for I_iter in eachindex(tmpf)
-            f_new[I_iter] = view(tmpf[I_iter], :, :)
+            f_new[I_iter] = tmpf[I_iter]
         end
-        B = gcmarray{T, 1, InnerArray{T,2}}(
+        return gcmarray{T, 1, InnerArray{T,2}}(
             A.grid, A.meta, f_new, fSize_sub, fIndex_sub, thisversion)
     else
-        # 2D result
-        f_new = OuterArray{InnerArray{T,2}, 2}(undef, nFaces, n3)
+        f_new = OuterArray{InnerArray{T,2},2}(undef, nFaces, n3)
         for I_iter in eachindex(tmpf)
-            f_new[I_iter] = view(tmpf[I_iter], :, :)
+            f_new[I_iter] = tmpf[I_iter]
         end
-        B = gcmarray{T, 2, InnerArray{T,2}}(
+        return gcmarray{T, 2, InnerArray{T,2}}(
             A.grid, A.meta, f_new, fSize_sub, fIndex_sub, thisversion)
     end
-    return B
 end
 
 # ### Custom pretty-printing, similar, and broadcast

--- a/test/testsets/broadcast.jl
+++ b/test/testsets/broadcast.jl
@@ -1,11 +1,11 @@
-@testset "broadcast .= equivalence" begin
-    γ = GridSpec(ID=:LLC90)
-    Γ = GridLoad(γ, option="full")
-    u = MeshArray(γ, Float32, 10)
-    for I in eachindex(u.f)
-        u.f[I] = rand(Float32, size(u.f[I])...)
-    end
+γ = GridSpec(ID=:LLC90)
+Γ = GridLoad(γ, option="full")
+u = MeshArray(γ, Float32, 10)
+for I in eachindex(u.f)
+    u.f[I] = rand(Float32, size(u.f[I])...)
+end
 
+@testset "broadcast .= equivalence" begin
     # Test 1: A .= B  (plain copy)
     u2 = similar(u, allocate=true)
     u2 .= u
@@ -24,4 +24,17 @@
     end
     u4 .= u .* 2.0f0
     @test all(I -> u4.f[I] == ref.f[I], eachindex(u.f))
+end
+
+@testset "broadcast slice .= equivalence" begin
+    # A[:,k] .= B[:,k] .* C  — the Drifters.jl pattern
+    u_eq  = similar(u, allocate=true)
+    u_deq = similar(u, allocate=true)
+
+    for k in 1:10
+        u_eq[:,k]  = u[:,k] .* Γ.DXC   # plain =
+        u_deq[:,k] .= u[:,k] .* Γ.DXC  # .= should match
+    end
+
+    @test all(I -> u_eq.f[I] == u_deq.f[I], eachindex(u_eq.f))
 end


### PR DESCRIPTION
## PR2: Fix slice broadcast `.=` for `AbstractMeshArray`

**Title:** Fix slice `.=` assignment (e.g. `A[:,k] .= rhs`) via corrected `Base.view`

**Follows:** PR1 (fix whole-array `copyto!` dispatch and `ones`/`zeros`/`fill` allocation)

---

### Problem

After PR #228, whole-array `.=` worked correctly. However slice assignment:

```julia
u[:,k] .= u[:,k] .* D.iDXC
```

silently wrote nothing — `u` remained unchanged. This is the original pattern in `Drifters.jl` that had been worked around with plain `=`.

---

### Root Cause — Two bugs in `Base.view`

**Bug 1 — Scalar `J` when indexing with a single face index**

```julia
J = 1:length(A.fIndex)
!isa(I[1], Colon) ? J = J[I[1]] : nothing  # J becomes Int when I[1] is Int
fSize_sub = A.fSize[J]   # returns NTuple{2,Int} instead of Array{NTuple{2,Int},1}
# → gcmarray constructor throws:
# Cannot convert Tuple{Int64,Int64} to Array{Tuple{Int64,Int64}}
```

**Bug 2 — `view(tmpf[I_iter], :, :)` wraps face in a SubArray**

```julia
f_new[I_iter] = view(tmpf[I_iter], :, :)   # SubArray wrapper — not the Matrix itself
```

When `copyto!` writes into `f_new[I_iter]`, it writes into the `SubArray` wrapper. The write does not reliably propagate back to the original `A.f[i,k]` — so `u` appears unchanged after `.=`.

---

### Test Added

```julia
@testset "broadcast slice .= equivalence" begin
    γ = GridSpec(ID=:LLC90)
    Γ = GridLoad(γ, option="full")
    u = MeshArray(γ, Float32, 10)
    for I in eachindex(u.f)
        u.f[I] = rand(Float32, size(u.f[I])...)
    end

    # A[:,k] .= B[:,k] .* C — the original Drifters.jl pattern
    u_eq  = similar(u, allocate=true)
    u_deq = similar(u, allocate=true)
    for k in 1:10
        u_eq[:,k]  = u[:,k] .* Γ.DXC    # plain =
        u_deq[:,k] .= u[:,k] .* Γ.DXC   # .= must match
    end
    @test all(I -> u_eq.f[I] == u_deq.f[I], eachindex(u_eq.f))
end
```
